### PR TITLE
Enable searching with vuln ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Search for known vulnerabilities in software using software titles or a CPE 2.3 
 
 Using the *search_vulns* tool, this local information can be queried, either by providing software titles like 'Apache 2.4.39' or by providing a CPE 2.3 string like ``cpe:2.3:a:sudo_project:sudo:1.8.2:*:*:*:*:*:*:*``.
 
+You can also search for vuln ids like 'CVE-2023-1234' or 'GHSA-xx68-jfcg-xmmf' using a comma-seperated list of these.
+
 *search_vulns* can either be used as a CLI tool or via a web server. It is recommended to use the CLI tool for automated workflows that might be resource-constrained. Otherwise, using the web server is recommended, because it offers more features and flexibility. This includes the ability to achieve more complete results. Also, the presentation of results is clearer and results can be exported for further use.
 
 

--- a/tests/test_cve_attr_completeness.py
+++ b/tests/test_cve_attr_completeness.py
@@ -100,6 +100,20 @@ class TestSearches(unittest.TestCase):
                 self.assertEqual(cve_attrs['cvss_vec'], expected_attrs[cve]['cvss_vec'])
                 self.assertEqual(cve_attrs['cisa_known_exploited'], expected_attrs[cve]['cisa_known_exploited'])
 
+    def test_search_cve_ghsa_ids(self):
+        self.maxDiff = None
+        query = 'CVE-2024-27286, GHSA-hfjr-m75m-wmh7, CVE-2024-12345678'
+        result = search_vulns.search_vulns(query=query, add_other_exploit_refs=True, is_good_cpe=True)
+        expected_attrs = {'CVE-2024-27286': {'published': '2024-03-20 20:15:08', 'cvss_ver': '3.1', 'cvss': '6.5', 'cvss_vec': 'CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N', 'cisa_known_exploited': False}, 'GHSA-hfjr-m75m-wmh7': {'published': '2022-05-24 16:59:38', 'cvss_ver': '3.1', 'cvss': '7.8', 'cvss_vec': 'CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H', 'cisa_known_exploited': False}, 'CVE-2024-12345678': {'published': '', 'cvss_ver': '', 'cvss': '-1.0', 'cvss_vec': '', 'cisa_known_exploited': False}}
+
+        for cve, cve_attrs in result[query]['vulns'].items():
+            if 'nvd' in cve_attrs['sources']:
+                self.assertIn(cve, expected_attrs)
+                self.assertEqual(cve_attrs['published'], expected_attrs[cve]['published'])
+                self.assertEqual(cve_attrs['cvss_ver'], expected_attrs[cve]['cvss_ver'])
+                self.assertEqual(cve_attrs['cvss'], expected_attrs[cve]['cvss'])
+                self.assertEqual(cve_attrs['cvss_vec'], expected_attrs[cve]['cvss_vec'])
+                self.assertEqual(cve_attrs['cisa_known_exploited'], expected_attrs[cve]['cisa_known_exploited'])
 
 if __name__ == '__main__':
     unittest.main()

--- a/web_server.py
+++ b/web_server.py
@@ -223,7 +223,9 @@ def search_vulns():
         VULN_RESULTS_CACHE[url_query_string] = {}
         return {}
     else:
-        VULN_RESULTS_CACHE[url_query_string] = vulns
+        # do not cache vuln ids search
+        if vulns[query]['cpe']:
+            VULN_RESULTS_CACHE[url_query_string] = vulns
         return vulns
 
 


### PR DESCRIPTION
Hi,
I implemented searching with vuln ids (CVEs and GHSAs) to have all information for vulns in one place.
You can search with a comma-seperated list of vuln ids.
CPE suggestions are disabled if a vuln ids query is detected. You could think about implementing suggestions for this type of query. It shouldn't be too much work, but I thought it is unnecessary for this context.
Also, these queries aren't cached in the web server, since caching them wouldn't be needed and would just fill the cache unnecessarily.
If a vuln id is not found in the database, the entry gets highlighted with a description of "NOT FOUND".

![image](https://github.com/user-attachments/assets/7efd5b06-f8f7-4579-bffa-6f2cc6980688)
