### PR TITLE
Add href to backpatched icon

### DIFF
--- a/src/search_vulns/web_server_files/static/js/search_vulns.js
+++ b/src/search_vulns/web_server_files/static/js/search_vulns.js
@@ -198,7 +198,7 @@ function createVulnTableRowHtml(idx, vuln) {
                 vuln_flag_html += `<br><center><span class="vuln-flag-icon" `;
             else
                 vuln_flag_html += '<span class="ml-2 vuln-flag-icon" ';
-            vuln_flag_html += `data-tooltip-target="tooltip-patched-${idx}" data-tooltip-placement="bottom"><i class="fa-solid fa-shield text-info"></i></span><div id="tooltip-patched-${idx}" role="tooltip" class="tooltip relative z-10 w-80 p-2 text-sm invisible rounded-lg shadow-sm opacity-0 bg-base-300" style="white-space:pre-wrap">This vulnerability was reported (back)patched for the queried version and environment.<div class="tooltip-arrow" data-popper-arrow></div></div>`;
+            vuln_flag_html += `data-tooltip-target="tooltip-patched-${idx}" data-tooltip-placement="bottom"><a href="${vuln.tracked_by[vuln.reported_patched_by[0]]}"><i class="fa-solid fa-shield text-info"></i></a></span><div id="tooltip-patched-${idx}" role="tooltip" class="tooltip relative z-10 w-80 p-2 text-sm invisible rounded-lg shadow-sm opacity-0 bg-base-300" style="white-space:pre-wrap">This vulnerability was reported (back)patched for the queried version and environment.<div class="tooltip-arrow" data-popper-arrow></div></div>`;
         }
 
         if (vuln_flag_html)


### PR DESCRIPTION
Hi,
I added href to backpatched icons.
You implemented vuln.reported_patched_by as a set so you're allowing multiple sources for reported_patched_by. This PR only handles the first element in the set and assumes an entry in vuln.tracked_by for the first element. This should not be a problem at the moment but it could be in the future.
To check my code, you can use the following queries:
`apache tomcat 9.0.70-2 debian 10`
`apache tomcat 9.0.70-2 ubuntu 25.04`
`cpe:2.3:a:apache:tomcat:9.0.70:*:*:*:*:*:*:rhel_9.1_9.0.70-2`