### PR TITLE
feat: integrate sv web api and batch processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ search_vulns' search engine is designed in a modular fashion. Therefore, new dat
 | Module ID | Description |
 |----------|-------------|
 | [nvd.<wbr>search_vulns_nvd](https://github.com/ra1nb0rn/search_vulns/blob/master/src/search_vulns/modules/nvd/search_vulns_nvd.py) | Integrates CVE information and exploits from the [National Vulnerability (NVD) database](https://nvd.nist.gov/) |
-| [vulncheck.<wbr>search_vulns_nvdpp](https://github.com/ra1nb0rn/search_vulns/blob/master/src/search_vulns/modules/vulncheck/search_vulns_nvdpp.py) | Integrates additional enrichment of the CVE/NVD data via [VulnCheck's NVD++](https://www.vulncheck.com/nvd2) |
+| [vulncheck.<wbr>search_vulns_nvdpp](https://github.com/ra1nb0rn/search_vulns/blob/master/src/search_vulns/modules/vulncheck/search_vulns_nvdpp.py) | Integrates additional enrichment of the CVE/NVD data via [VulnCheck's NVD++](https://www.vulncheck.com/nvd2) alongside [its KEV data](https://www.vulncheck.com/kev)|
 | [ghsa.<wbr>search_vulns_ghsa](https://github.com/ra1nb0rn/search_vulns/blob/master/src/search_vulns/modules/ghsa/search_vulns_ghsa.py) | Integrates CVE and non-CVE vulnerabilties from the [GitHub Security Advisory (GHSA) database](https://github.com/github/advisory-database) |
 | [exploit_db.<wbr>search_vulns_edb](https://github.com/ra1nb0rn/search_vulns/blob/master/src/search_vulns/modules/exploit_db/search_vulns_edb.py) | Integrates publicly available exploits from the [Exploit-DB](https://www.exploit-db.com/) |
 | [poc_in_github.<wbr>search_vulns_poc_in_github](https://github.com/ra1nb0rn/search_vulns/blob/master/src/search_vulns/modules/poc_in_github/search_vulns_poc_in_github.py) | Integrates exploit information from [PoC-in-GitHub](https://github.com/nomi-sec/PoC-in-GitHub) |

--- a/src/search_vulns/cli.py
+++ b/src/search_vulns/cli.py
@@ -3,109 +3,46 @@
 import argparse
 import json
 import os
-import re
 import sys
 
+from .cli_backend import DEFAULT_API_URL, select_backend
+from .cli_formatters import (
+    BRIGHT_BLUE,
+    RED,
+    YELLOW,
+    format_ansi,
+    format_json_batch,
+    format_md,
+    parse_md_cols,
+    print_vulns,
+    printit,
+    sort_and_cap_vulns,
+    strip_ansi,
+)
+from .cli_interactive import run_interactive_loop
 from .core import (
     DEFAULT_CONFIG_FILE,
     _load_config,
-    check_and_try_sv_rerun_with_created_cpes,
     get_modules,
     get_version,
     is_fully_installed,
-    search_vulns,
 )
 
-# define ANSI color escape sequences
-# Taken from: http://www.lihaoyi.com/post/BuildyourownCommandLinewithANSIescapecodes.html
-# and: http://www.topmudsites.com/forums/showthread.php?t=413
-SANE = "\u001b[0m"
-GREEN = "\u001b[32m"
-BRIGHT_GREEN = "\u001b[32;1m"
-RED = "\u001b[31m"
-YELLOW = "\u001b[33m"
-BRIGHT_BLUE = "\u001b[34;1m"
-MAGENTA = "\u001b[35m"
-BRIGHT_CYAN = "\u001b[36;1m"
 
-DEDUP_LINEBREAKS_RE_1 = re.compile(r"(\r\n)+")
-DEDUP_LINEBREAKS_RE_2 = re.compile(r"\n+")
+# ------------------------------------------------ helpers
+def _read_query_file(path: str) -> list:
+    try:
+        with open(path, encoding="utf-8") as fh:
+            return [
+                line.strip() for line in fh
+                if line.strip() and not line.strip().startswith("#")
+            ]
+    except OSError as exc:
+        print(f"Error: Cannot read query file '{path}': {exc}", file=sys.stderr)
+        sys.exit(1)
 
 
-def printit(text: str = "", end: str = "\n", color=SANE):
-    """A small print wrapper function"""
-
-    print(color, end="")
-    print(text, end=end)
-    if color != SANE:
-        print(SANE, end="")
-    sys.stdout.flush()
-
-
-def print_vulns(vulns, to_string=False):
-    """Print the supplied vulnerabilities"""
-
-    out_string = ""
-    vuln_ids_sorted = sorted(
-        list(vulns), key=lambda vuln_Id: vulns[vuln_Id].get_cvss_score(), reverse=True
-    )
-    for vuln_id in vuln_ids_sorted:
-        vuln_node = vulns[vuln_id]
-        description = DEDUP_LINEBREAKS_RE_2.sub(
-            "\n", DEDUP_LINEBREAKS_RE_1.sub("\r\n", vuln_node.description.strip())
-        )
-
-        if not to_string:
-            print_str = GREEN + vuln_node.id + SANE
-            print_str += (
-                " ("
-                + MAGENTA
-                + "CVSSv"
-                + str(vuln_node.get_cvss_version())
-                + "/"
-                + str(vuln_node.get_cvss_score())
-                + SANE
-                + ")"
-            )
-            if vuln_node.cisa_kev:
-                print_str += " (" + RED + "Actively exploited" + SANE + ")"
-        else:
-            print_str = vuln_node.id
-            print_str += (
-                " ("
-                "CVSSv"
-                + vuln_node.get_cvss_version()
-                + "/"
-                + str(vuln_node.get_cvss_score())
-                + ")"
-            )
-            if vuln_node.cisa_kev:
-                print_str += " (Actively exploited)"
-        print_str += ": " + description + "\n"
-
-        if vuln_node.exploits:
-            vuln_exploits = list(vuln_node.exploits)
-            if not to_string:
-                print_str += YELLOW + "Exploits:  " + SANE + vuln_exploits[0] + "\n"
-            else:
-                print_str += "Exploits:  " + vuln_exploits[0] + "\n"
-
-            if len(vuln_exploits) > 1:
-                for edb_link in vuln_exploits[1:]:
-                    print_str += len("Exploits:  ") * " " + edb_link + "\n"
-
-        print_str += "Reference: " + vuln_node.aliases[vuln_node.id]
-        if vuln_node.published:
-            print_str += ", " + vuln_node.published.strftime("%Y-%m-%d")
-        if not to_string:
-            printit(print_str)
-        else:
-            out_string += print_str + "\n"
-
-    if to_string:
-        return out_string
-
-
+# ------------------------------------------------ arg parsing
 def parse_args():
     """Parse command line arguments"""
 
@@ -146,8 +83,8 @@ def parse_args():
         "--format",
         type=str,
         default="txt",
-        choices={"txt", "json"},
-        help="Output format, either 'txt' or 'json' (default: 'txt')",
+        choices={"txt", "json", "ansi", "md"},
+        help="Output format: txt, json, ansi, or md (default: txt)",
     )
     parser.add_argument(
         "-o", "--output", type=str, help="File to write found vulnerabilities to"
@@ -199,6 +136,42 @@ def parse_args():
         action="store_true",
         help="Include vulnerabilities reported as (back)patched, e.g. by Debian Security Tracker, in results",
     )
+    parser.add_argument(
+        "--api-key",
+        type=str,
+        default=None,
+        help="API key for remote search (overrides SV_API_KEY env var)",
+    )
+    parser.add_argument(
+        "--api-url",
+        type=str,
+        default=None,
+        help=f"API base URL (default: {DEFAULT_API_URL})",
+    )
+    parser.add_argument(
+        "--query-file",
+        type=str,
+        default=None,
+        help="File with queries, one per line (# comments and blank lines skipped)",
+    )
+    parser.add_argument(
+        "-i",
+        "--interactive",
+        action="store_true",
+        help="Interactive mode: suggest product IDs, pick, then search",
+    )
+    parser.add_argument(
+        "--vuln-count",
+        type=int,
+        default=None,
+        help="Max number of vulnerabilities per query (sorted by criticality)",
+    )
+    parser.add_argument(
+        "--md-cols",
+        type=str,
+        default=None,
+        help="Columns for markdown format (default: id,cvss,description)",
+    )
 
     args = parser.parse_args()
     if (
@@ -209,11 +182,14 @@ def parse_args():
         and not args.version
         and not args.full_install
         and not args.list_modules
+        and not args.interactive
+        and not args.query_file
     ):
         parser.print_help()
     return args
 
 
+# ------------------------------------------------ main
 def main():
     # parse args and run update routine if requested
     args = parse_args()
@@ -283,107 +259,138 @@ def main():
         else:
             print("[+] Update successful")
 
-    if not args.queries:
+    # Collect queries
+    queries = list(args.queries or [])
+    if args.query_file:
+        queries.extend(_read_query_file(args.query_file))
+
+    if not queries and not args.interactive:
         return
 
-    # retrieve known vulnerabilities for every query and print them
+    # Select backend and build search kwargs
     config = _load_config(args.config)
+    backend = select_backend(args, config)
+
+    search_kwargs = {
+        "ignore_general_product_vulns": args.ignore_general_product_vulns,
+        "include_single_version_vulns": args.include_single_version_vulns,
+        "include_patched": args.include_patched,
+        "use_created_product_ids": args.use_created_product_ids,
+    }
+
+    fmt = args.format.lower()
+    if args.interactive and fmt == "txt":
+        fmt = "ansi"
+
+    md_cols = parse_md_cols(args.md_cols or "id,cvss,description")
+
+    # Interactive mode
+    if args.interactive:
+        def render_result(query, sv_result):
+            if args.vuln_count is not None:
+                sv_result.vulns = sort_and_cap_vulns(sv_result.vulns, args.vuln_count)
+            if fmt == "ansi":
+                print(format_ansi(query, sv_result))
+            elif fmt == "md":
+                print(format_md(sv_result, md_cols))
+            elif fmt == "txt":
+                all_product_ids = sv_result.product_ids.get_all()
+                printit("[+] %s (" % query, color=BRIGHT_BLUE, end="")
+                printit("/".join(all_product_ids) + ")", color=BRIGHT_BLUE)
+                print_vulns(sv_result.vulns)
+            elif fmt == "json":
+                print(json.dumps({query: sv_result.model_dump(exclude_none=True)}))
+
+        run_interactive_loop(
+            backend,
+            seed_queries=queries or None,
+            render_result=render_result,
+            search_kwargs=search_kwargs,
+        )
+        return
+
+    # Batch mode
     all_vulns = {}
     out_string = ""
-    for query in args.queries:
-        # Prepare arguments and search for vulnerabilities
+    md_blocks = []
+
+    for query in queries:
         query = query.strip()
 
-        if args.cpe_search_threshold:
-            config["MODULES"]["cpe_search.search_vulns_cpe_search"][
-                "CPE_SEARCH_THRESHOLD"
-            ] = args.cpe_search_threshold
-        config["MODULES"]["cpe_search.search_vulns_cpe_search"][
-            "CPE_SEARCH_COUNT"
-        ] = 1  # limit for CLI usage
-
-        if args.format.lower() == "txt":
+        if fmt == "txt":
             if not args.output:
                 printit("[+] %s (" % query, color=BRIGHT_BLUE, end="")
             else:
                 out_string += "[+] %s (" % query
 
-        sv_result = search_vulns(
-            query,
-            None,
-            None,
-            None,
-            False,
-            args.ignore_general_product_vulns,
-            args.include_single_version_vulns,
-            args.include_patched,
-            config,
-        )
-
-        # check if result is good, i.e. vulns or product IDs were found
-        is_good_result, sv_result = check_and_try_sv_rerun_with_created_cpes(
-            query,
-            sv_result,
-            args.ignore_general_product_vulns,
-            args.include_single_version_vulns,
-            args.include_patched,
-            args.use_created_product_ids,
-            config,
-        )
+        is_good_result, sv_result = backend.search(query, **search_kwargs)
         all_product_ids = sv_result.product_ids.get_all()
 
         if not is_good_result:
-            if args.format.lower() == "txt":
+            if fmt == "txt":
                 if not args.output:
                     printit(")", color=BRIGHT_BLUE)
                     printit("Warning: Could not find matching software for query", color=RED)
                     printit()
-                    continue
                 else:
                     out_string += ")\nWarning: Could not find matching software for query\n\n"
-            else:
+            elif fmt == "json":
                 all_vulns[query] = "Warning: Could not find matching software for query"
             continue
 
-        if args.format.lower() == "txt":
+        if fmt == "txt":
             if not args.output:
                 printit("/".join(all_product_ids) + ")", color=BRIGHT_BLUE)
             else:
                 out_string += "/".join(all_product_ids) + ")\n"
 
-        # "sort" vulnerabilities by CVSS score
-        if sv_result.vulns:
+        # Apply vuln-count capping
+        if args.vuln_count is not None:
+            sv_result.vulns = sort_and_cap_vulns(sv_result.vulns, args.vuln_count)
+
+        # Sort vulns by CVSS for txt/json (preserves original behavior)
+        if fmt in ("txt", "json") and sv_result.vulns:
             vuln_ids_sorted = sorted(
                 list(sv_result.vulns),
                 key=lambda vuln_id: sv_result.vulns[vuln_id].get_cvss_score(),
                 reverse=True,
             )
-            sorted_vulns = {}
-            for vuln_id in vuln_ids_sorted:
-                sorted_vulns[vuln_id] = sv_result.vulns[vuln_id]
-            sv_result.vulns = sorted_vulns
+            sv_result.vulns = {vid: sv_result.vulns[vid] for vid in vuln_ids_sorted}
 
-        # prepare output
-        if args.format.lower() == "txt":
-            # print found vulnerabilities
+        if fmt == "txt":
             if not args.output:
                 print_vulns(sv_result.vulns)
             else:
-                out_string += print_vulns(sv_result.vulns, to_string=True)
-        else:
-            sv_result = sv_result.model_dump(exclude_none=True)
+                out_string += print_vulns(sv_result.vulns, to_string=True) or ""
+        elif fmt == "ansi":
+            block = format_ansi(query, sv_result)
+            if not args.output:
+                print(block)
+            else:
+                out_string += strip_ansi(block) + "\n"
+        elif fmt == "md":
+            md_blocks.append(format_md(sv_result, md_cols))
 
         all_vulns[query] = sv_result
 
-    # provide final output
-    if args.output:
+    # Final output
+    if fmt == "json":
+        json_str = format_json_batch(all_vulns)
+        if args.output:
+            with open(args.output, "w") as f:
+                f.write(json_str)
+        else:
+            print(json_str)
+    elif fmt == "md":
+        md_output = "\n\n".join(md_blocks)
+        if args.output:
+            with open(args.output, "w") as f:
+                f.write(md_output)
+        else:
+            print(md_output)
+    elif args.output:
         with open(args.output, "w") as f:
-            if args.format.lower() == "json":
-                f.write(json.dumps(all_vulns))
-            else:
-                f.write(out_string)
-    elif args.format.lower() == "json":
-        print(json.dumps(all_vulns))
+            f.write(out_string)
 
 
 if __name__ == "__main__":

--- a/src/search_vulns/cli_backend.py
+++ b/src/search_vulns/cli_backend.py
@@ -1,0 +1,259 @@
+"""Backend abstraction for local DB and remote API searches"""
+
+import json
+import os
+import sys
+
+from typing import Protocol, Tuple
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote, urlencode
+from urllib.request import Request, urlopen
+
+from .models.SearchVulnsResult import (
+    PotProductIDsResult,
+    ProductIDsResult,
+    SearchVulnsResult,
+    VersionStatus,
+    VersionStatusResult,
+)
+from .models.Severity import SeverityCVSS, SeverityEPSS, SeverityType
+from .models.Vulnerability import DataSource, Match, MatchReason, Vulnerability
+
+from .core import search_vulns
+from .core import check_and_try_sv_rerun_with_created_cpes, search_vulns
+
+
+DEFAULT_API_URL = "https://search-vulns.com/api/"
+
+
+class ApiError(Exception):
+    pass
+
+
+class SearchBackend(Protocol):
+    def suggest(self, query: str) -> SearchVulnsResult: ...
+    def search(self, query: str, **kwargs) -> Tuple[bool, SearchVulnsResult]: ...
+
+
+# ------------------------------------------------ local backend
+class LocalBackend:
+    def __init__(self, config: dict, cli_overrides: dict | None = None):
+        self._config = config
+        self._overrides = cli_overrides or {}
+
+    def _apply_overrides(self, config: dict) -> dict:
+        import copy
+        cfg = copy.deepcopy(config)
+        if "cpe_search_threshold" in self._overrides and self._overrides["cpe_search_threshold"]:
+            cfg["MODULES"]["cpe_search.search_vulns_cpe_search"]["CPE_SEARCH_THRESHOLD"] = (
+                self._overrides["cpe_search_threshold"]
+            )
+        cfg["MODULES"]["cpe_search.search_vulns_cpe_search"]["CPE_SEARCH_COUNT"] = 1
+        return cfg
+
+    def suggest(self, query: str) -> SearchVulnsResult:
+        cfg = self._apply_overrides(self._config)
+        return search_vulns(query, config=cfg, skip_vuln_search=True)
+
+    def search(self, query: str, **kwargs) -> Tuple[bool, SearchVulnsResult]:
+        cfg = self._apply_overrides(self._config)
+        is_product_id = kwargs.get("is_good_product_id", False)
+
+        sv_result = search_vulns(
+            query,
+            None,
+            None,
+            None,
+            is_product_id,
+            kwargs.get("ignore_general_product_vulns", False),
+            kwargs.get("include_single_version_vulns", False),
+            kwargs.get("include_patched", False),
+            cfg,
+        )
+
+        is_good, sv_result = check_and_try_sv_rerun_with_created_cpes(
+            query,
+            sv_result,
+            kwargs.get("ignore_general_product_vulns", False),
+            kwargs.get("include_single_version_vulns", False),
+            kwargs.get("include_patched", False),
+            kwargs.get("use_created_product_ids", False),
+            cfg,
+        )
+        return is_good, sv_result
+
+
+# ------------------------------------------------ API backend
+class ApiBackend:
+    def __init__(self, api_key: str, api_url: str = DEFAULT_API_URL):
+        self._api_key = api_key
+        self._api_url = api_url.rstrip("/")
+
+    def _api_get(self, endpoint: str, params: dict, *, fatal: bool = True) -> dict:
+        qs = urlencode(params, quote_via=quote)
+        url = f"{self._api_url}{endpoint}?{qs}"
+        req = Request(url, headers={"API-Key": self._api_key})
+        errmsg = None
+
+        try:
+            with urlopen(req, timeout=30) as resp:
+                return json.loads(resp.read().decode())
+        except HTTPError as exc:
+            body = exc.read().decode()
+            try:
+                detail = json.loads(body)
+                msg = detail.get("message") or detail.get("detail") or body
+            except json.JSONDecodeError:
+                msg = body
+            errmsg = f"HTTP {exc.code}: {msg}"
+        except URLError as exc:
+            errmsg = f"Network error: {exc.reason}"
+
+        if fatal:
+            print(f"Error: {errmsg}", file=sys.stderr)
+            sys.exit(1)
+        raise ApiError(errmsg)
+
+    def suggest(self, query: str) -> SearchVulnsResult:
+        data = self._api_get("/product-id-suggestions", {"query": query})
+        return _parse_api_result(data)
+
+    def search(self, query: str, **kwargs) -> Tuple[bool, SearchVulnsResult]:
+        params: dict = {"query": query}
+
+        flag_map = {
+            "ignore_general_product_vulns": "ignore-general-product-vulns",
+            "include_single_version_vulns": "include-single-version-vulns",
+            "include_patched": "include-patched",
+            "use_created_product_ids": "use-created-product-ids",
+            "is_good_product_id": "is-good-product-id",
+        }
+        for attr, param in flag_map.items():
+            val = kwargs.get(attr)
+            if val is not None:
+                params[param] = str(val).lower()
+
+        data = self._api_get("/search-vulns", params)
+        result = _parse_api_result(data)
+        is_good = bool(result.product_ids.get_all()) or bool(result.vulns)
+        return is_good, result
+
+
+# ------------------------------------------------ API response parsing
+def _parse_severity(raw: dict) -> dict:
+    severity = {}
+    for _, entry in raw.items():
+        stype = entry.get("type", "")
+        if stype == "CVSS":
+            severity[SeverityType.CVSS] = SeverityCVSS(
+                score=str(entry.get("score", "0")),
+                version=str(entry.get("version", "0")),
+                vector=entry.get("vector", "n/a"),
+            )
+        elif stype == "EPSS":
+            severity[SeverityType.EPSS] = SeverityEPSS(
+                score=str(entry.get("score", "0")),
+            )
+    return severity
+
+
+def _parse_vuln(vid: str, raw: dict) -> Vulnerability:
+    tracked_by = {}
+    for src, ref in raw.get("tracked_by", {}).items():
+        try:
+            tracked_by[DataSource(src)] = ref
+        except ValueError:
+            tracked_by[src] = ref
+
+    matched_by = {}
+    for src, match_data in raw.get("matched_by", {}).items():
+        try:
+            ds = DataSource(src)
+        except ValueError:
+            ds = src
+        matched_by[ds] = Match(
+            match_reason=MatchReason(match_data.get("match_reason", "n_a")),
+            confidence=match_data.get("confidence", 1.0),
+        )
+
+    match_reason_str = raw.get("match_reason", "n_a")
+    try:
+        match_reason = MatchReason(match_reason_str)
+    except ValueError:
+        match_reason = MatchReason.N_A
+
+    kwargs = dict(
+        id=vid,
+        match_reason=match_reason,
+        tracked_by=tracked_by or {DataSource.OTHER: ""},
+        matched_by=matched_by or {DataSource.OTHER: Match(match_reason=match_reason, confidence=1.0)},
+        description=raw.get("description", ""),
+        severity=_parse_severity(raw.get("severity", {})),
+        cisa_kev=raw.get("cisa_kev", False),
+        exploits=set(raw.get("exploits", [])),
+        cwe_ids=set(raw.get("cwe_ids", [])),
+        aliases=raw.get("aliases", {vid: ""}),
+    )
+    if raw.get("published"):
+        kwargs["published"] = raw["published"]
+    if raw.get("modified"):
+        kwargs["modified"] = raw["modified"]
+
+    return Vulnerability(**kwargs)
+
+
+def _parse_api_result(data: dict) -> SearchVulnsResult:
+    pids = data.get("product_ids", {})
+    product_ids = ProductIDsResult(
+        cpe=pids.get("cpe", []),
+        purl=pids.get("purl", []),
+        raw=pids.get("raw", []),
+    )
+
+    pot = data.get("pot_product_ids", {})
+    pot_product_ids = PotProductIDsResult(
+        cpe=[(e[0], e[1]) for e in pot.get("cpe", [])],
+        purl=[(e[0], e[1]) for e in pot.get("purl", [])],
+        raw=[(e[0], e[1]) for e in pot.get("raw", [])],
+    )
+
+    vulns = {}
+    for vid, raw_vuln in data.get("vulns", {}).items():
+        vulns[vid] = _parse_vuln(vid, raw_vuln)
+
+    vs_data = data.get("version_status", {})
+    vs_status = None
+    if vs_data.get("status"):
+        try:
+            vs_status = VersionStatus(vs_data["status"])
+        except ValueError:
+            pass
+    version_status = VersionStatusResult(
+        status=vs_status,
+        latest=vs_data.get("latest"),
+        reference=vs_data.get("reference"),
+    )
+
+    return SearchVulnsResult(
+        product_ids=product_ids,
+        pot_product_ids=pot_product_ids,
+        vulns=vulns,
+        version_status=version_status,
+    )
+
+
+# ------------------------------------------------ backend selection
+def select_backend(args, config: dict) -> SearchBackend:
+    api_key = getattr(args, "api_key", None) or os.environ.get("SV_API_KEY")
+    api_url = getattr(args, "api_url", None)
+
+    if api_key or (api_url and api_url != DEFAULT_API_URL):
+        if not api_key:
+            print("Error: --api-url requires --api-key or SV_API_KEY env var.", file=sys.stderr)
+            sys.exit(1)
+        return ApiBackend(api_key, api_url or DEFAULT_API_URL)
+
+    overrides = {}
+    if hasattr(args, "cpe_search_threshold"):
+        overrides["cpe_search_threshold"] = args.cpe_search_threshold
+    return LocalBackend(config, overrides)

--- a/src/search_vulns/cli_formatters.py
+++ b/src/search_vulns/cli_formatters.py
@@ -1,0 +1,419 @@
+"""Provides txt, ansi, md, and json output formats"""
+
+import json
+import re
+from typing import Dict, Optional
+
+from .models.SearchVulnsResult import SearchVulnsResult
+from .models.Vulnerability import Vulnerability
+
+SANE = "\033[0m"
+GREEN = "\033[32m"
+BRIGHT_GREEN = "\033[32;1m"
+RED = "\033[31m"
+YELLOW = "\033[33m"
+BRIGHT_BLUE = "\033[34;1m"
+MAGENTA = "\033[35m"
+BRIGHT_CYAN = "\033[36;1m"
+BOLD = "\033[1m"
+DIM = "\033[2m"
+CYAN = "\033[36m"
+
+DEDUP_LINEBREAKS_RE_1 = re.compile(r"(\r\n)+")
+DEDUP_LINEBREAKS_RE_2 = re.compile(r"\n+")
+
+_ANSI_RE = re.compile(r"\033\[[0-9;]*m")
+
+ALLOWED_MD_COLS = ("id", "cvss", "description", "epss", "cwe", "exploits")
+DEFAULT_MD_COLS = ("id", "cvss", "description")
+
+_MD_COL_HEADERS = {
+    "id": "Vuln ID",
+    "cvss": "CVSS",
+    "description": "Description",
+    "epss": "EPSS",
+    "cwe": "CWE",
+    "exploits": "Exploits",
+}
+
+_MD_COL_ALIGN = {
+    "id": ":---:",
+    "cvss": ":---:",
+    "description": ":---",
+    "epss": ":---:",
+    "cwe": ":---:",
+    "exploits": ":---:",
+}
+
+_SEVERITY_ORDER = {"CRITICAL": 0, "HIGH": 1, "MEDIUM": 2, "LOW": 3, "UNKNOWN": 4}
+
+
+# ------------------------------------------------ helpers
+def printit(text: str = "", end: str = "\n", color=SANE):
+    """Small print wrapper with ANSI colour support."""
+    import sys
+
+    print(color, end="")
+    print(text, end=end)
+    if color != SANE:
+        print(SANE, end="")
+    sys.stdout.flush()
+
+
+def strip_ansi(text: str) -> str:
+    return _ANSI_RE.sub("", text)
+
+
+def _cvss_severity(score: float) -> str:
+    if score >= 9.0:
+        return "CRITICAL"
+    if score >= 7.0:
+        return "HIGH"
+    if score >= 4.0:
+        return "MEDIUM"
+    if score > 0.0:
+        return "LOW"
+    return "UNKNOWN"
+
+
+def _cvss_color(severity: str, color: bool = True) -> str:
+    if not color:
+        return ""
+    return {
+        "CRITICAL": RED,
+        "HIGH": RED,
+        "MEDIUM": YELLOW,
+        "LOW": GREEN,
+    }.get(severity, DIM)
+
+
+def _ansi(value: str, color: bool) -> str:
+    if color:
+        return value
+    return ""
+
+
+def _md_escape(text: str) -> str:
+    return text.replace("\\", "\\\\").replace("|", "\\|").replace("\r\n", " ").replace("\n", " ")
+
+
+def _parse_cpe(cpe: str) -> tuple:
+    parts = cpe.split(":")
+    vendor = parts[3] if len(parts) > 3 else ""
+    product = parts[4] if len(parts) > 4 else ""
+    version = parts[5] if len(parts) > 5 else ""
+    product = product.replace("_", " ").title()
+    vendor = vendor.replace("_", " ").title()
+    return vendor, product, version
+
+
+def parse_md_cols(raw: str) -> list:
+    cols = []
+    for col in raw.split(","):
+        col = col.strip().lower()
+        if not col:
+            continue
+        if col not in ALLOWED_MD_COLS:
+            raise ValueError(
+                f"Unknown markdown column '{col}'. Allowed: {', '.join(ALLOWED_MD_COLS)}"
+            )
+        if col not in cols:
+            cols.append(col)
+    if not cols:
+        return list(DEFAULT_MD_COLS)
+    return cols
+
+
+def sort_and_cap_vulns(
+    vulns: Dict[str, Vulnerability], max_count: Optional[int]
+) -> Dict[str, Vulnerability]:
+    if not vulns:
+        return {}
+
+    def sort_key(vuln_id):
+        v = vulns[vuln_id]
+        cvss = float(v.get_cvss_score())
+        epss_raw = v.get_epss_score()
+        epss = float(epss_raw) if epss_raw not in (None, "-1") else 0.0
+        return (-cvss, -epss, vuln_id)
+
+    sorted_ids = sorted(vulns.keys(), key=sort_key)
+
+    if max_count is not None:
+        sorted_ids = sorted_ids[:max_count]
+
+    return {vid: vulns[vid] for vid in sorted_ids}
+
+
+def score_bar(score: float, width: int = 12) -> str:
+    score = abs(score)
+    normalised = min(score, 1.0)
+    filled = round(normalised * width)
+    if score >= 0.6:
+        colour = GREEN
+    elif score >= 0.2:
+        colour = YELLOW
+    else:
+        colour = RED
+    bar = f"{colour}{'█' * filled}{DIM}{'░' * (width - filled)}{SANE}"
+    return f"{bar} {colour}{score:+.2f}{SANE}"
+
+
+# ------------------------------------------------ txt
+def print_vulns(vulns: Dict[str, Vulnerability], to_string: bool = False) -> Optional[str]:
+    out_string = ""
+    vuln_ids_sorted = sorted(
+        list(vulns), key=lambda vid: vulns[vid].get_cvss_score(), reverse=True
+    )
+    for vuln_id in vuln_ids_sorted:
+        vuln_node = vulns[vuln_id]
+        description = DEDUP_LINEBREAKS_RE_2.sub(
+            "\n", DEDUP_LINEBREAKS_RE_1.sub("\r\n", vuln_node.description.strip())
+        )
+
+        if not to_string:
+            print_str = GREEN + vuln_node.id + SANE
+            print_str += (
+                " ("
+                + MAGENTA
+                + "CVSSv"
+                + str(vuln_node.get_cvss_version())
+                + "/"
+                + str(vuln_node.get_cvss_score())
+                + SANE
+                + ")"
+            )
+            if vuln_node.cisa_kev:
+                print_str += " (" + RED + "Actively exploited" + SANE + ")"
+        else:
+            print_str = vuln_node.id
+            print_str += (
+                " ("
+                "CVSSv"
+                + vuln_node.get_cvss_version()
+                + "/"
+                + str(vuln_node.get_cvss_score())
+                + ")"
+            )
+            if vuln_node.cisa_kev:
+                print_str += " (Actively exploited)"
+        print_str += ": " + description + "\n"
+
+        if vuln_node.exploits:
+            vuln_exploits = list(vuln_node.exploits)
+            if not to_string:
+                print_str += YELLOW + "Exploits:  " + SANE + vuln_exploits[0] + "\n"
+            else:
+                print_str += "Exploits:  " + vuln_exploits[0] + "\n"
+
+            if len(vuln_exploits) > 1:
+                for edb_link in vuln_exploits[1:]:
+                    print_str += len("Exploits:  ") * " " + edb_link + "\n"
+
+        print_str += "Reference: " + vuln_node.aliases[vuln_node.id]
+        if vuln_node.published:
+            print_str += ", " + vuln_node.published.strftime("%Y-%m-%d")
+        if not to_string:
+            printit(print_str)
+        else:
+            out_string += print_str + "\n"
+
+    if to_string:
+        return out_string
+
+# ------------------------------------------------ ansi
+def _format_version_status(version_status, color: bool = True) -> str:
+    if not version_status or not version_status.status:
+        return ""
+
+    status = version_status.status.value if hasattr(version_status.status, "value") else str(version_status.status)
+    if status == "N/A":
+        return ""
+
+    status_color = {
+        "EOL": YELLOW,
+        "OUTDATED": YELLOW,
+        "CURRENT": GREEN,
+    }.get(status, DIM)
+
+    parts = [f"{_ansi(BOLD, color)}Status:{_ansi(SANE, color)} {_ansi(status_color, color)}{status}{_ansi(SANE, color)}"]
+    if version_status.latest:
+        parts.append(f"{_ansi(BOLD, color)}Latest:{_ansi(SANE, color)} {version_status.latest}")
+    if version_status.reference:
+        parts.append(f"{_ansi(DIM, color)}{version_status.reference}{_ansi(SANE, color)}")
+
+    return f"\n  {'  |  '.join(parts)}\n"
+
+
+def _format_vuln_table(vulns: Dict[str, Vulnerability], color: bool = True) -> str:
+    if not vulns:
+        return f"  {_ansi(GREEN, color)}No vulnerabilities found.{_ansi(SANE, color)}\n"
+
+    rows = []
+    for vid, vuln in vulns.items():
+        cvss = float(vuln.get_cvss_score())
+        epss_raw = vuln.get_epss_score()
+        epss = float(epss_raw) if epss_raw not in (None, "-1") else 0.0
+        severity = _cvss_severity(cvss)
+        sev_order = _SEVERITY_ORDER.get(severity, 99)
+
+        cvss_str = f"{cvss:.1f}"
+        cvss_ver = vuln.get_cvss_version()
+        if cvss_ver and str(cvss_ver) != "-1":
+            cvss_str += f"v{cvss_ver}"
+
+        epss_str = f"{epss:.2f}" if epss > 0 else "-"
+        published = vuln.published.strftime("%Y-%m-%d") if vuln.published else ""
+        desc = vuln.description or ""
+        if len(desc) > 60:
+            desc = desc[:57] + "..."
+
+        badges = ""
+        if vuln.cisa_kev:
+            badges += f" {_ansi(RED, color)}KEV{_ansi(SANE, color)}"
+        if vuln.exploits:
+            badges += f" {_ansi(MAGENTA, color)}EXP x{len(vuln.exploits)}{_ansi(SANE, color)}"
+
+        sev_color = _cvss_color(severity, color)
+        sane = _ansi(SANE, color)
+        line = (
+            f"  {sev_color}{vid:<20}{sane} "
+            f"{sev_color}{cvss_str:>7}{sane}  "
+            f"{epss_str:>5}  {published:<10}  {desc}{badges}"
+        )
+        rows.append((sev_order, -cvss, vid, line))
+
+    rows.sort(key=lambda r: (r[0], r[1], r[2]))
+
+    bold = _ansi(BOLD, color)
+    sane = _ansi(SANE, color)
+    lines = [
+        f"  {bold}{'ID':<20} {'CVSS':>7}  {'EPSS':>5}  {'Published':<10}  Description{sane}",
+        f"  {'─' * 78}",
+    ]
+
+    sev_names = {v: k for k, v in _SEVERITY_ORDER.items()}
+    current_sev = -1
+    for sev_order, _, _, line in rows:
+        if sev_order != current_sev:
+            current_sev = sev_order
+            label = sev_names.get(sev_order, "OTHER")
+            lines.append(f"\n  {bold}{_cvss_color(label, color)}── {label} ──{sane}")
+        lines.append(line)
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def format_ansi(query: str, sv_result: SearchVulnsResult, color: bool = True) -> str:
+    bold = _ansi(BOLD, color)
+    bright_blue = _ansi(BRIGHT_BLUE, color)
+    sane = _ansi(SANE, color)
+
+    parts = []
+
+    all_pids = sv_result.product_ids.get_all()
+    pid_str = "/".join(all_pids) if all_pids else "no product IDs"
+    parts.append(f"{bright_blue}[+] {query} ({pid_str}){sane}")
+
+    vs_str = _format_version_status(sv_result.version_status, color)
+    if vs_str:
+        parts.append(vs_str)
+
+    n = len(sv_result.vulns)
+    parts.append(
+        f"\n  {bold}{n} vulnerabilit{'y' if n == 1 else 'ies'} found{sane}\n"
+    )
+    parts.append(_format_vuln_table(sv_result.vulns, color))
+
+    return "\n".join(parts)
+
+
+# ------------------------------------------------ md
+def _md_frontmatter(sv_result: SearchVulnsResult) -> str:
+    cpes = sv_result.product_ids.cpe
+    if cpes:
+        cpe = cpes[0]
+        _, product, version = _parse_cpe(cpe)
+    else:
+        cpe = ""
+        product = ""
+        version = ""
+
+    lines = [
+        "---",
+        f'cpe: "{cpe}"',
+        f'product: "{product}"',
+        f'version: "{version}"',
+        "---",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def _md_cell(vuln: Vulnerability, col: str) -> str:
+    if col == "id":
+        ref = vuln.aliases.get(vuln.id, "")
+        if ref:
+            return f"[{_md_escape(vuln.id)}]({ref})"
+        return _md_escape(vuln.id)
+
+    if col == "cvss":
+        cvss = float(vuln.get_cvss_score())
+        if cvss < 0:
+            return "-"
+        ver = vuln.get_cvss_version()
+        if ver and str(ver) != "-1":
+            return f"{cvss} (v{ver})"
+        return str(cvss)
+
+    if col == "description":
+        return _md_escape(vuln.description or "")
+
+    if col == "epss":
+        epss_raw = vuln.get_epss_score()
+        epss = float(epss_raw) if epss_raw not in (None, "-1") else 0.0
+        if epss > 0:
+            return f"{epss:.2f}"
+        return "-"
+
+    if col == "cwe":
+        if vuln.cwe_ids:
+            return ", ".join(sorted(vuln.cwe_ids))
+        return "-"
+
+    if col == "exploits":
+        if vuln.exploits:
+            return str(len(vuln.exploits))
+        return "-"
+
+    return "-"
+
+
+def format_md(sv_result: SearchVulnsResult, cols: list) -> str:
+    parts = [_md_frontmatter(sv_result)]
+
+    headers = [_MD_COL_HEADERS.get(c, c) for c in cols]
+    aligns = [_MD_COL_ALIGN.get(c, ":---") for c in cols]
+
+    parts.append("| " + " | ".join(headers) + " |")
+    parts.append("| " + " | ".join(aligns) + " |")
+
+    sorted_vulns = sort_and_cap_vulns(sv_result.vulns, None)
+    for vid in sorted_vulns:
+        vuln = sorted_vulns[vid]
+        cells = [_md_cell(vuln, c) for c in cols]
+        parts.append("| " + " | ".join(cells) + " |")
+
+    return "\n".join(parts)
+
+
+# ------------------------------------------------ json
+def format_json_batch(all_results: dict) -> str:
+    serializable = {}
+    for query, result in all_results.items():
+        if isinstance(result, SearchVulnsResult):
+            serializable[query] = result.model_dump(exclude_none=True)
+        else:
+            serializable[query] = result
+    return json.dumps(serializable)

--- a/src/search_vulns/cli_interactive.py
+++ b/src/search_vulns/cli_interactive.py
@@ -1,0 +1,119 @@
+"""Interactive REPL: suggest -> pick -> search -> render loop"""
+
+import sys
+from typing import Callable
+
+from .cli_backend import SearchBackend
+from .cli_formatters import BOLD, CYAN, DIM, GREEN, RED, SANE, score_bar
+from .models.SearchVulnsResult import SearchVulnsResult
+
+_QUIT_WORDS = {"q", "quit", "exit"}
+
+
+# ------------------------------------------------ helpers
+def _prompt(text: str) -> str:
+    try:
+        return input(text).strip()
+    except (EOFError, KeyboardInterrupt):
+        print()
+        return "q"
+
+
+def _gather_suggestions(sv_result: SearchVulnsResult) -> list:
+    items = []
+    for cpe in sv_result.product_ids.cpe:
+        items.append((cpe, 1.0, "cpe"))
+    for purl in sv_result.product_ids.purl:
+        items.append((purl, 1.0, "purl"))
+    for raw in sv_result.product_ids.raw:
+        items.append((raw, 1.0, "raw"))
+
+    for cpe, score in sv_result.pot_product_ids.cpe:
+        if not any(i[0] == cpe for i in items):
+            items.append((cpe, abs(score), "cpe"))
+    for purl, score in sv_result.pot_product_ids.purl:
+        if not any(i[0] == purl for i in items):
+            items.append((purl, abs(score), "purl"))
+    for raw, score in sv_result.pot_product_ids.raw:
+        if not any(i[0] == raw for i in items):
+            items.append((raw, abs(score), "raw"))
+
+    items.sort(key=lambda x: -x[1])
+    return items
+
+
+def _pick_from_menu(items: list) -> str | None:
+    if not items:
+        return None
+
+    print(f"\n{BOLD}{CYAN}── Product IDs ──{SANE}\n")
+
+    for idx, (identifier, score, kind) in enumerate(items, 1):
+        print(f"  {BOLD}{idx:>3}{SANE})  {score_bar(score)}  [{kind}] {identifier}")
+
+    print(f"\n  {DIM}  0)  ← skip / new query{SANE}")
+    print()
+
+    while True:
+        raw = _prompt(f"{BOLD}Select [0–{len(items)}]:{SANE} ")
+        if raw.lower() in _QUIT_WORDS:
+            return None
+        if not raw:
+            continue
+        try:
+            choice = int(raw)
+        except ValueError:
+            print(f"  {RED}Please enter a number.{SANE}")
+            continue
+        if choice == 0:
+            return None
+        if 1 <= choice <= len(items):
+            selected = items[choice - 1][0]
+            print(f"\n{GREEN}Selected:{SANE} {BOLD}{selected}{SANE}\n")
+            return selected
+        print(f"  {RED}Out of range.{SANE}")
+
+
+# ------------------------------------------------ main loop
+def run_interactive_loop(
+    backend: SearchBackend,
+    *,
+    seed_queries: list | None = None,
+    render_result: Callable[[str, SearchVulnsResult], None],
+    search_kwargs: dict,
+):
+    pending = list(seed_queries or [])
+
+    while True:
+        if pending:
+            query = pending.pop(0)
+            print(f"\n{DIM}Query:{SANE} {BOLD}{query}{SANE}")
+        else:
+            query = _prompt(f"\n{BOLD}Enter query{SANE} ({DIM}q to quit{SANE}): ")
+            if query.lower() in _QUIT_WORDS:
+                break
+            if not query:
+                continue
+
+        print(f"{DIM}Searching suggestions...{SANE}", file=sys.stderr)
+        sv_suggest = backend.suggest(query)
+        items = _gather_suggestions(sv_suggest)
+
+        if not items:
+            print(f"{RED}No product IDs found for '{query}'.{SANE}")
+            continue
+
+        selected = _pick_from_menu(items)
+        if selected is None:
+            continue
+
+        print(f"{DIM}Searching vulnerabilities...{SANE}", file=sys.stderr)
+        is_good, sv_result = backend.search(
+            selected, is_good_product_id=True, **search_kwargs
+        )
+
+        if not is_good:
+            print(f"{RED}No results for '{selected}'.{SANE}")
+            continue
+
+        render_result(query, sv_result)

--- a/src/search_vulns/modules/euvd/search_vulns_euvd.py
+++ b/src/search_vulns/modules/euvd/search_vulns_euvd.py
@@ -58,19 +58,45 @@ def full_update(productdb_config, vulndb_config, module_config, stop_update):
 
 def add_extra_vuln_info(vulns: Dict[str, Vulnerability], vuln_db_cursor, config, extra_params):
     # Add EUVD aliases to vulnerabilities having CVE identifiers
-    for vuln_id, vuln in vulns.items():
-        if vuln_id.startswith("CVE-") and not any("EUVD-" in alias for alias in vuln.aliases):
-            vuln_db_cursor.execute(
-                "SELECT euvd_id FROM euvd WHERE cve_id = ?",
-                (vuln_id,),
-            )
-            for alias in vuln_db_cursor.fetchall():
-                alias = alias[0]
-                href = VULN_TRACK_BASE_URL + alias
-                vuln.add_alias(alias, href)
 
-                # no actual tracking of vulns yet
-                # if alias not in vuln.aliases:
-                #     vuln.add_tracked_by_with_alias(DataSource.GHSA, href, alias)
+    # gather all cve_ids
+    all_cve_ids = set()
+    for vuln_id, vuln in vulns.items():
+        if vuln_id.startswith("CVE-"):
+            all_cve_ids.add(vuln_id)
+        for alias in vuln.aliases:
+            if alias.startswith("CVE-"):
+                all_cve_ids.add(alias)
+
+    # make one joint SQL query with all involved cve_ids
+    placeholders = ",".join(["?"] * len(all_cve_ids))  # → "?,?,?,..."
+    if all_cve_ids:
+        vuln_db_cursor.execute(
+            f"SELECT cve_id, euvd_id FROM euvd WHERE cve_id IN ({placeholders})",
+            list(all_cve_ids),
+        )
+        cve_euvd = vuln_db_cursor.fetchall()
+    else:
+        cve_euvd = []
+
+    # create cve_id --> euvd_id map
+    cve_euvd_map = {}
+    for cve_id, euvd_id in cve_euvd:
+        if cve_id not in cve_euvd_map:
+            cve_euvd_map[cve_id] = set()
+        cve_euvd_map[cve_id].add(euvd_id)
+
+    # finally, add EUVD aliases
+    for vuln_id, vuln in vulns.items():
+        for alias in vuln.aliases | {vuln.id: ""}:
+            if alias.startswith("CVE-"):
+                for euvd_id in cve_euvd_map.get(alias, []):
+                    if euvd_id not in vuln.aliases:
+                        href = VULN_TRACK_BASE_URL + alias
+                        vuln.add_alias(euvd_id, href)
+
+                        # no actual tracking of vulns yet
+                        # if alias not in vuln.aliases:
+                        #     vuln.add_tracked_by_with_alias(DataSource.GHSA, href, alias)
 
     # TODO: EUVD KEV

--- a/src/search_vulns/modules/euvd/search_vulns_euvd.py
+++ b/src/search_vulns/modules/euvd/search_vulns_euvd.py
@@ -1,0 +1,76 @@
+import logging
+from typing import Dict
+
+import requests
+import ujson
+
+from search_vulns.models.Vulnerability import Vulnerability
+from search_vulns.modules.utils import SQLITE_TIMEOUT, get_database_connection
+
+VULN_TRACK_BASE_URL = "https://euvd.enisa.europa.eu/vulnerability/"
+LOGGER = logging.getLogger()
+
+
+def full_update(productdb_config, vulndb_config, module_config, stop_update):
+    # download and parse KEV data
+    resp = requests.get("https://euvdservices.enisa.europa.eu/api/kev/dump")
+    if resp.status_code != 200:
+        LOGGER.error("Could not retrieve EUVD KEV data")
+        return False, []
+    euvd_kev = set()
+    for kev_item in ujson.loads(resp.text):
+        if "eukev_kev" in kev_item["sources"]:
+            euvd_kev.add(kev_item["euvdId"])
+
+    # download EUVD <-> CVE mapping
+    resp = requests.get("https://euvdservices.enisa.europa.eu/api/dump/cve-euvd-mapping")
+    if resp.status_code != 200:
+        LOGGER.error("Could not retrieve EUVD <-> CVE mapping")
+        return False, []
+
+    # set up connection to vuln DB
+    db_conn = get_database_connection(vulndb_config, sqlite_timeout=SQLITE_TIMEOUT)
+    db_cursor = db_conn.cursor()
+    if vulndb_config["TYPE"] == "sqlite":
+        create_cve_edbids_table = "DROP TABLE IF EXISTS euvd; CREATE TABLE euvd (euvd_id VARCHAR(25), cve_id VARCHAR(25), euvd_kev BOOL, PRIMARY KEY (euvd_id));"
+    elif vulndb_config["TYPE"] == "mariadb":
+        create_cve_edbids_table = "CREATE OR REPLACE TABLE euvd (euvd_id VARCHAR(25) CHARACTER SET ascii, cve_id VARCHAR(25) CHARACTER SET ascii, euvd_kev BOOL, PRIMARY KEY (euvd_id));"
+    # necessary because SQLite can't handle more than one query a time
+    for query in create_cve_edbids_table.split(";"):
+        if query:
+            db_cursor.execute(query + ";")
+    db_conn.commit()
+
+    # simple processing, skip header line
+    insert_statement = "INSERT INTO euvd VALUES(?, ?, ?)"
+    for line in resp.text.splitlines()[1:]:
+        euvd, cve = line.split(",")
+        if not cve or not euvd:
+            continue
+        if euvd in euvd_kev:
+            db_cursor.execute(insert_statement, (euvd, cve, True))
+        else:
+            db_cursor.execute(insert_statement, (euvd, cve, False))
+
+    db_conn.commit()
+    db_conn.close()
+
+
+def add_extra_vuln_info(vulns: Dict[str, Vulnerability], vuln_db_cursor, config, extra_params):
+    # Add EUVD aliases to vulnerabilities having CVE identifiers
+    for vuln_id, vuln in vulns.items():
+        if vuln_id.startswith("CVE-") and not any("EUVD-" in alias for alias in vuln.aliases):
+            vuln_db_cursor.execute(
+                "SELECT euvd_id FROM euvd WHERE cve_id = ?",
+                (vuln_id,),
+            )
+            for alias in vuln_db_cursor.fetchall():
+                alias = alias[0]
+                href = VULN_TRACK_BASE_URL + alias
+                vuln.add_alias(alias, href)
+
+                # no actual tracking of vulns yet
+                # if alias not in vuln.aliases:
+                #     vuln.add_tracked_by_with_alias(DataSource.GHSA, href, alias)
+
+    # TODO: EUVD KEV

--- a/src/search_vulns/modules/ghsa/build.py
+++ b/src/search_vulns/modules/ghsa/build.py
@@ -237,7 +237,9 @@ def parse_ghsa_data(vulndb_cursor, productdb_config):
                     # try to retrieve a CPE for the product name by comparing it with the NVD's affected CPEs
                     most_similar = None
                     for cpe in all_nvd_cpes:
-                        sim = compute_cosine_similarity(cpe[10:], pname + " " + " ".join(add_keywords), r"[a-zA-Z0-9]+")
+                        sim = compute_cosine_similarity(
+                            cpe[10:], pname + " " + " ".join(add_keywords), r"[a-zA-Z0-9]+"
+                        )
                         if not most_similar or sim > most_similar[1]:
                             most_similar = (cpe, sim)
 

--- a/src/search_vulns/modules/ghsa/build.py
+++ b/src/search_vulns/modules/ghsa/build.py
@@ -214,6 +214,14 @@ def parse_ghsa_data(vulndb_cursor, productdb_config):
                         )
                         all_nvd_cpes.add(cpe_version_wildcarded)
 
+            # steer matching toward certain CPEs ...
+            add_keywords = []
+
+            # ... e.g. libraries if vuln affects a library, .e.g. CVE-2025-10492/GHSA-7c3f-cg9x-f3gr
+            if "library" in advisory["details"].lower():
+                add_keywords.append("library")
+
+            # attempt matching with CPE in NVD entry
             for pname in advisory_affected_pnames:
                 if pname in pname_cpe_map:
                     continue
@@ -229,7 +237,7 @@ def parse_ghsa_data(vulndb_cursor, productdb_config):
                     # try to retrieve a CPE for the product name by comparing it with the NVD's affected CPEs
                     most_similar = None
                     for cpe in all_nvd_cpes:
-                        sim = compute_cosine_similarity(cpe[10:], pname, r"[a-zA-Z0-9]+")
+                        sim = compute_cosine_similarity(cpe[10:], pname + " " + " ".join(add_keywords), r"[a-zA-Z0-9]+")
                         if not most_similar or sim > most_similar[1]:
                             most_similar = (cpe, sim)
 

--- a/src/search_vulns/modules/ghsa/search_vulns_ghsa.py
+++ b/src/search_vulns/modules/ghsa/search_vulns_ghsa.py
@@ -129,17 +129,46 @@ def search_vulns(
 
 def add_extra_vuln_info(vulns: Dict[str, Vulnerability], vuln_db_cursor, config, extra_params):
     # Add GHSA aliases to vulnerabilities having CVE identifiers
+
+    # gather all cve_ids
+    all_cve_ids = set()
     for vuln_id, vuln in vulns.items():
-        if vuln_id.startswith("CVE-") and not any("GHSA-" in alias for alias in vuln.aliases):
-            vuln_db_cursor.execute(
-                "SELECT ghsa_id FROM ghsa WHERE aliases = ? OR aliases LIKE ?",
-                (vuln_id, "%%" + vuln_id + ",%%"),
-            )
-            for alias in vuln_db_cursor.fetchall():
-                alias = alias[0]
-                href = VULN_TRACK_BASE_URL + alias
-                if alias not in vuln.aliases:
-                    vuln.add_tracked_by_with_alias(DataSource.GHSA, href, alias)
+        if vuln_id.startswith("CVE-"):
+            all_cve_ids.add(vuln_id)
+        for alias in vuln.aliases:
+            if alias.startswith("CVE-"):
+                all_cve_ids.add(alias)
+
+    # make one joint SQL query with all involved cve_ids
+    if all_cve_ids:
+        conditions = " OR ".join(["(aliases = ? OR aliases LIKE ?)"] * len(all_cve_ids))
+        params = [param for cve_id in all_cve_ids for param in (cve_id, "%" + cve_id + ",%")]
+        vuln_db_cursor.execute(
+            f"SELECT ghsa_id, aliases FROM ghsa WHERE {conditions}",
+            params,
+        )
+        cve_ghsa = vuln_db_cursor.fetchall()
+    else:
+        cve_ghsa = []
+
+    # create cve_id --> ghsa_id map
+    cve_ghsa_map = {}
+    for ghsa_id, aliases in cve_ghsa:
+        for alias in aliases.split(","):
+            if alias.startswith("CVE-"):
+                if alias not in cve_ghsa_map:
+                    cve_ghsa_map[alias] = set()
+                cve_ghsa_map[alias].add(ghsa_id)
+
+    # finally, add GHSA aliases
+    for vuln_id, vuln in vulns.items():
+        for alias in vuln.aliases | {vuln.id: ""}:
+            if alias.startswith("CVE-"):
+                for ghsa_id in cve_ghsa_map.get(alias, []):
+                    if ghsa_id not in vuln.aliases:
+                        href = VULN_TRACK_BASE_URL + alias
+                        if alias not in vuln.aliases:
+                            vuln.add_tracked_by_with_alias(DataSource.GHSA, href, alias)
 
 
 def postprocess_results(

--- a/src/search_vulns/modules/linux_distro_backpatches/ubuntu/build.py
+++ b/src/search_vulns/modules/linux_distro_backpatches/ubuntu/build.py
@@ -35,7 +35,7 @@ REQUIRES_BUILT_MODULES = [
 ]
 LOGGER = logging.getLogger()
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
-UBUNTU_RELEASES_API_URL = "https://ubuntu.com/security/releases.json"
+UBUNTU_RELEASES_URL = "https://salsa.debian.org/debian/distro-info-data/-/raw/main/ubuntu.csv"
 UBUNTU_DATAFEED_DIR = os.path.join(SCRIPT_DIR, "ubuntu_data_feeds")
 UBUNTU_RELEASES = {}
 DISTRO_CODENAMES = []
@@ -53,66 +53,43 @@ def create_ubuntu_release_codename_mapping(vulndb_config):
 
     global UBUNTU_RELEASES
 
-    # initial request to set paramters
-    headers = {
-        "accept": "application/json",
-        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:112.0) Gecko/20100101 Firefox/112.0",
-    }
-
-    # try multiple times over, since the API has connection issues
-    success = False
-    for _ in range(10):
-        try:
-            # time out after 1s
-            ubuntu_api_initial_response = requests.get(
-                UBUNTU_RELEASES_API_URL, headers=headers, timeout=1
-            )
-            ubuntu_api_initial_response.raise_for_status()  # Optional: treat HTTP errors as failures
-            success = True
-            break
-        except requests.RequestException as e:
-            pass
-
-    if not success:
-        LOGGER.error(
-            "Could not retrieve Ubuntu releases from https://ubuntu.com/security/releases.json"
-        )
+    try:
+        resp = requests.get(UBUNTU_RELEASES_URL)
+        resp.raise_for_status()
+    except:
+        LOGGER.error("Could not retrieve Ubuntu releases from %s" % UBUNTU_RELEASES_URL)
         return False
-    releases_raw = ubuntu_api_initial_response.json()["releases"]
 
+    # store release data in DB and create UBUNTU_RELEASES mapping
     db_conn = get_database_connection(vulndb_config, sqlite_timeout=SQLITE_TIMEOUT)
     db_cursor = db_conn.cursor()
-
-    # create codename-version table in vulndb
     if vulndb_config["TYPE"] == "sqlite":
         db_cursor.execute("DROP TABLE IF EXISTS ubuntu_codename_version_mapping;")
         create_mapping_table = "CREATE TABLE ubuntu_codename_version_mapping (version VARCHAR(23), codename VARCHAR(25), support_expires DATETIME, esm_lts_expires DATETIME, PRIMARY KEY(codename));"
     elif vulndb_config["TYPE"] == "mariadb":
         create_mapping_table = "CREATE OR REPLACE TABLE ubuntu_codename_version_mapping (version VARCHAR(15) CHARACTER SET ascii, codename VARCHAR(25) CHARACTER SET ascii, support_expires DATETIME, esm_lts_expires DATETIME, PRIMARY KEY(codename));"
     db_cursor.execute(create_mapping_table)
-
     query = "INSERT INTO ubuntu_codename_version_mapping (version, codename, support_expires, esm_lts_expires) VALUES (?, ?, ?, ?)"
 
-    # extract codename and version from json
-    for release in releases_raw:
-        codename = release["codename"]
-
-        if codename == "upstream":
-            # use big number as version for upstream
-            if not release["version"]:
-                version = 999
-            if not release["support_expires"]:
-                support_expires = "9999-12-31"
-            if not release["esm_expires"]:
-                esm_expires = "9999-12-31"
-        else:
-            version = release["version"]
-            support_expires = str(release["support_expires"]).split("T")[0]
-            esm_expires = str(release["esm_expires"]).split("T")[0]
+    # parse simple CSV data, skipping header
+    for release_raw in resp.text.splitlines()[1:]:
+        release_data = release_raw.split(",")
+        if len(release_data) > 5:
+            version = release_data[0].replace(" LTS", "")
+            codename = release_data[2]
+            support_expires = release_data[5]
+            if len(release_data) > 7:
+                esm_expires = release_data[7]
+            else:
+                esm_expires = support_expires
 
         # add information to database and dict
         db_cursor.execute(query, (version, codename, support_expires, esm_expires))
         UBUNTU_RELEASES[codename] = version
+
+    # add artificial upstream
+    db_cursor.execute(query, (999, "upstream", "9999-12-31", "9999-12-31"))
+    UBUNTU_RELEASES["upstream"] = 999
 
     db_conn.commit()
     db_conn.close()

--- a/src/search_vulns/modules/vulncheck/build.py
+++ b/src/search_vulns/modules/vulncheck/build.py
@@ -1,4 +1,5 @@
 import gzip
+import io
 import logging
 import os
 import shutil
@@ -157,6 +158,71 @@ def store_affects_statements(vulndb_config, affects_statements):
     db_conn.close()
 
 
+def download_and_store_kev_data(vulndb_config, vulncheck_api_key):
+    """Download and store Vulncheck KEV data via backup API"""
+
+    # download data
+    headers = {"Authorization": "Bearer %s" % vulncheck_api_key}
+    resp = requests.get("https://api.vulncheck.com/v3/backup/vulncheck-kev", headers=headers)
+    resp.raise_for_status()
+    resp = resp.json()
+    dl_url = resp["data"][0]["url"]
+    resp = requests.get(dl_url)
+    resp.raise_for_status()
+    with zipfile.ZipFile(io.BytesIO(resp.content)) as zf:
+        with zf.open(zf.namelist()[0]) as f:
+            kev_data = ujson.load(f)
+
+    # set up DB stuff
+    db_conn = get_database_connection(vulndb_config, sqlite_timeout=SQLITE_TIMEOUT)
+    db_cursor = db_conn.cursor()
+
+    if vulndb_config["TYPE"] == "sqlite":
+        create_vulncheck_kev_table = "DROP TABLE IF EXISTS vulncheck_kev; CREATE TABLE vulncheck_kev (cve_id VARCHAR(25), PRIMARY KEY (cve_id));"
+        create_vulncheck_exploits_table = "DROP TABLE IF EXISTS vulncheck_exploits; CREATE TABLE vulncheck_exploits (cve_id VARCHAR(25), url VARCHAR(200), PRIMARY KEY (cve_id, url));"
+    elif vulndb_config["TYPE"] == "mariadb":
+        create_vulncheck_kev_table = "CREATE OR REPLACE TABLE vulncheck_kev (cve_id VARCHAR(25) CHARACTER SET ascii, PRIMARY KEY (cve_id));"
+        create_vulncheck_exploits_table = "CREATE OR REPLACE TABLE vulncheck_exploits (cve_id VARCHAR(25) CHARACTER SET ascii, url VARCHAR(200) CHARACTER SET ascii, PRIMARY KEY (cve_id, url));"
+
+    # necessary because SQLite can't handle more than one query a time
+    for query in create_vulncheck_kev_table.split(";"):
+        if query:
+            db_cursor.execute(query + ";")
+    for query in create_vulncheck_exploits_table.split(";"):
+        if query:
+            db_cursor.execute(query + ";")
+    db_conn.commit()
+
+    # parse data and store it in DBs
+    insert_kev_query = "INSERT INTO vulncheck_kev VALUES(?)"
+    insert_exploit_query = "INSERT INTO vulncheck_exploits VALUES(?, ?)"
+    for kev in kev_data:
+        # parse data
+        exploits = set()
+        cves = kev["cve"]
+        for xdb in kev["vulncheck_xdb"]:
+            exploit_ref = xdb["clone_ssh_url"].strip()
+            if exploit_ref:
+                if "@" in exploit_ref:
+                    # transform ssh clone URL to web URL
+                    exploit_ref = exploit_ref[exploit_ref.find("@") + 1 :]
+                    exploit_ref = exploit_ref.replace(":", "/", 1)
+                    exploit_ref = "https://" + exploit_ref
+                    if exploit_ref.endswith(".git"):
+                        exploit_ref = exploit_ref[:-4]
+                exploits.add(exploit_ref)
+
+        # put into DB
+        for cve in cves:
+            db_cursor.execute(insert_kev_query, (cve,))
+            for exploit in exploits:
+                db_cursor.execute(insert_exploit_query, (cve, exploit))
+
+    db_conn.commit()
+    db_cursor.close()
+    db_conn.close()
+
+
 def full_update(productdb_config, vulndb_config, module_config, stop_update):
     """Perform full update"""
 
@@ -167,8 +233,12 @@ def full_update(productdb_config, vulndb_config, module_config, stop_update):
     if vulncheck_api_key:
         LOGGER.info("[+] Adding CVE (NVD) <-> CPE information from VulnCheck")
 
+        # retrieve and store vuln data
         vuln_data_dir = download_nvdpp_data(vulncheck_api_key)
         affects_statements = extract_affects_statements(vuln_data_dir, vulndb_config)
         store_affects_statements(vulndb_config, affects_statements)
 
         shutil.rmtree(str(vuln_data_dir))
+
+        # retrieve and store KEV data
+        download_and_store_kev_data(vulndb_config, vulncheck_api_key)

--- a/src/search_vulns/modules/vulncheck/search_vulns_nvdpp.py
+++ b/src/search_vulns/modules/vulncheck/search_vulns_nvdpp.py
@@ -36,7 +36,7 @@ def search_vulns(
 
 
 def add_extra_vuln_info(vulns: Dict[str, Vulnerability], vuln_db_cursor, config, extra_params):
-    # check and append tracking information
+    # check and append tracking, exploit and KEV information
     for vuln_id, vuln in vulns.items():
         # get all CVE IDs
         vuln_cve_ids = set()
@@ -51,6 +51,7 @@ def add_extra_vuln_info(vulns: Dict[str, Vulnerability], vuln_db_cursor, config,
             in_str += "%s," % cve_id
         in_str = in_str[:-1]  # remove last comma
 
+        # tracking information
         if DataSource.NVDPP not in vuln.tracked_by and in_str:
             vuln_db_cursor.execute(
                 "SELECT COUNT(*) FROM vulncheck_nvd_cpe WHERE cve_id IN (?)", (in_str,)
@@ -59,3 +60,14 @@ def add_extra_vuln_info(vulns: Dict[str, Vulnerability], vuln_db_cursor, config,
             if count and int(count[0]) > 0:
                 # add track reference
                 vuln.add_tracked_by(DataSource.NVDPP, VULN_TRACK_BASE_URL + vuln_id)
+
+        # exploits
+        if in_str:
+            vuln_db_cursor.execute(
+                "SELECT url FROM vulncheck_exploits WHERE cve_id IN (?)", (in_str,)
+            )
+            for exploit in vuln_db_cursor.fetchall():
+                vuln.add_exploit(exploit[0])
+
+        # TODO: check and append KEV
+        # resulting KEV URL for proof later: https://api.vulncheck.com/v3/index/vulncheck-kev?cve=CVE-2025-2825

--- a/src/search_vulns/web_server_files/static/css/daisyui.css
+++ b/src/search_vulns/web_server_files/static/css/daisyui.css
@@ -48,6 +48,7 @@
     --radius-md: 0.375rem;
     --radius-lg: 0.5rem;
     --ease-out: cubic-bezier(0, 0, 0.2, 1);
+    --ease-in-out: cubic-bezier(0.4, 0, 0.2, 1);
     --default-transition-duration: 150ms;
     --default-transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
     --default-font-family: var(--font-sans);
@@ -686,6 +687,48 @@
       }
     }
   }
+  .collapse-arrow {
+    @layer daisyui.l1.l2 {
+      > .collapse-title:after {
+        position: absolute;
+        display: block;
+        height: 0.5rem;
+        width: 0.5rem;
+        transform: translateY(-100%) rotate(45deg);
+        @media (prefers-reduced-motion: no-preference) {
+          transition-property: all;
+          transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+          transition-duration: 0.2s;
+        }
+        top: 50%;
+        inset-inline-end: 1.4rem;
+        content: "";
+        transform-origin: 75% 75%;
+        box-shadow: 2px 2px;
+        pointer-events: none;
+      }
+    }
+  }
+  .collapse-plus {
+    @layer daisyui.l1.l2 {
+      > .collapse-title:after {
+        position: absolute;
+        display: block;
+        height: 0.5rem;
+        width: 0.5rem;
+        @media (prefers-reduced-motion: no-preference) {
+          transition-property: all;
+          transition-duration: 300ms;
+          transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+        }
+        top: 0.9rem;
+        inset-inline-end: 1.4rem;
+        --tw-content: "+";
+        content: var(--tw-content);
+        pointer-events: none;
+      }
+    }
+  }
   .dropdown {
     @layer daisyui.l1.l2.l3 {
       position: relative;
@@ -1136,6 +1179,40 @@
       }
     }
   }
+  .collapse-content {
+    @layer daisyui.l1.l2.l3 {
+      grid-column-start: 1;
+      grid-row-start: 1;
+    }
+    @layer daisyui.l1.l2.l3 {
+      content-visibility: hidden;
+      grid-column-start: 1;
+      grid-row-start: 2;
+      min-height: 0;
+      padding-left: 1rem;
+      padding-right: 1rem;
+      cursor: unset;
+      @supports not (content-visibility: hidden) {
+        visibility: hidden;
+      }
+      @media (prefers-reduced-motion: no-preference) {
+        transition: content-visibility 0.2s allow-discrete, visibility 0.2s allow-discrete, min-height 0.2s ease-out allow-discrete, padding 0.1s ease-out 20ms, background-color 0.2s ease-out;
+      }
+    }
+  }
+  .collapse-open {
+    @layer daisyui.l1.l2 {
+      grid-template-rows: max-content 1fr;
+      > .collapse-content {
+        content-visibility: visible;
+        min-height: fit-content;
+        padding-bottom: 1rem;
+        @supports not (content-visibility: visible) {
+          visibility: visible;
+        }
+      }
+    }
+  }
   .collapse {
     visibility: collapse;
   }
@@ -1200,6 +1277,27 @@
         }
         > * {
           grid-row-start: 1;
+        }
+      }
+    }
+  }
+  .toast {
+    @layer daisyui.l1.l2.l3 {
+      position: fixed;
+      inset-inline-start: auto;
+      inset-inline-end: calc(0.25rem * 4);
+      top: auto;
+      bottom: calc(0.25rem * 4);
+      display: flex;
+      flex-direction: column;
+      gap: calc(0.25rem * 2);
+      background-color: transparent;
+      translate: var(--toast-x, 0) var(--toast-y, 0);
+      width: max-content;
+      max-width: calc(100vw - 2rem);
+      & > * {
+        @media (prefers-reduced-motion: no-preference) {
+          animation: toast 0.25s ease-out;
         }
       }
     }
@@ -1794,6 +1892,20 @@
       }
     }
   }
+  .collapse-title {
+    @layer daisyui.l1.l2.l3 {
+      grid-column-start: 1;
+      grid-row-start: 1;
+    }
+    @layer daisyui.l1.l2.l3 {
+      position: relative;
+      width: 100%;
+      padding: 1rem;
+      padding-inline-end: 3rem;
+      min-height: 1lh;
+      transition: background-color 0.2s ease-out;
+    }
+  }
   .sr-only {
     position: absolute;
     width: 1px;
@@ -1997,6 +2109,74 @@
       }
     }
   }
+  .rating {
+    @layer daisyui.l1.l2.l3 {
+      position: relative;
+      display: inline-flex;
+      vertical-align: middle;
+      & input {
+        border: none;
+        appearance: none;
+      }
+      :where(*) {
+        height: calc(0.25rem * 6);
+        width: calc(0.25rem * 6);
+        border-radius: 0;
+        background-color: var(--color-base-content);
+        opacity: 20%;
+        @media (prefers-reduced-motion: no-preference) {
+          animation: rating 0.25s ease-out;
+        }
+        &:is(input) {
+          cursor: pointer;
+        }
+      }
+      & .rating-hidden {
+        width: calc(0.25rem * 2);
+        background-color: transparent;
+      }
+      input[type="radio"]:checked {
+        background-image: none;
+      }
+      * {
+        &:checked, &[aria-checked="true"], &[aria-current="true"], &:has(~ *:checked, ~ *[aria-checked="true"], ~ *[aria-current="true"]) {
+          opacity: 100%;
+        }
+        &:focus-visible {
+          scale: 1.1;
+          @media (prefers-reduced-motion: no-preference) {
+            transition: scale 0.2s ease-out;
+          }
+        }
+      }
+      & *:active:focus {
+        animation: none;
+        scale: 1.1;
+      }
+    }
+    @layer daisyui.l1.l2 {
+      &.rating-xs :where(*:not(.rating-hidden)) {
+        width: calc(0.25rem * 4);
+        height: calc(0.25rem * 4);
+      }
+      &.rating-sm :where(*:not(.rating-hidden)) {
+        width: calc(0.25rem * 5);
+        height: calc(0.25rem * 5);
+      }
+      &.rating-md :where(*:not(.rating-hidden)) {
+        width: calc(0.25rem * 6);
+        height: calc(0.25rem * 6);
+      }
+      &.rating-lg :where(*:not(.rating-hidden)) {
+        width: calc(0.25rem * 7);
+        height: calc(0.25rem * 7);
+      }
+      &.rating-xl :where(*:not(.rating-hidden)) {
+        width: calc(0.25rem * 8);
+        height: calc(0.25rem * 8);
+      }
+    }
+  }
   .navbar {
     @layer daisyui.l1.l2.l3 {
       display: flex;
@@ -2123,6 +2303,18 @@
       }
     }
   }
+  .dropdown-left {
+    @layer daisyui.l1.l2 {
+      --anchor-h: left;
+      --anchor-v: span-bottom;
+      .dropdown-content {
+        inset-inline-end: 100%;
+        top: calc(0.25rem * 0);
+        bottom: auto;
+        transform-origin: 100%;
+      }
+    }
+  }
   .dropdown-center {
     @layer daisyui.l1.l2 {
       --anchor-h: center;
@@ -2196,6 +2388,9 @@
   }
   .top-\[3px\] {
     top: 3px;
+  }
+  .top-\[calc\(100\%\+4px\)\] {
+    top: calc(100% + 4px);
   }
   .right-0 {
     right: calc(var(--spacing) * 0);
@@ -2421,6 +2616,47 @@
   .z-\[10\] {
     z-index: 10;
   }
+  .tab-content {
+    @layer daisyui.l1.l2.l3 {
+      order: var(--tabcontent-order);
+      display: none;
+      border-color: transparent;
+      --tabcontent-radius-ss: var(--radius-box);
+      --tabcontent-radius-se: var(--radius-box);
+      --tabcontent-radius-es: var(--radius-box);
+      --tabcontent-radius-ee: var(--radius-box);
+      --tabcontent-order: 1;
+      width: 100%;
+      height: calc(100% - var(--tab-height) + var(--border));
+      margin: var(--tabcontent-margin);
+      border-width: var(--border);
+      border-start-start-radius: var(--tabcontent-radius-ss);
+      border-start-end-radius: var(--tabcontent-radius-se);
+      border-end-start-radius: var(--tabcontent-radius-es);
+      border-end-end-radius: var(--tabcontent-radius-ee);
+    }
+  }
+  .modal-box {
+    @layer daisyui.l1.l2.l3 {
+      grid-column-start: 1;
+      grid-row-start: 1;
+      max-height: 100vh;
+      width: calc(11/12 * 100%);
+      max-width: 32rem;
+      background-color: var(--color-base-100);
+      padding: calc(0.25rem * 6);
+      transition: translate 0.3s ease-out, scale 0.3s ease-out, opacity 0.2s ease-out 0.05s, box-shadow 0.3s ease-out;
+      border-top-left-radius: var(--modal-tl, var(--radius-box));
+      border-top-right-radius: var(--modal-tr, var(--radius-box));
+      border-bottom-left-radius: var(--modal-bl, var(--radius-box));
+      border-bottom-right-radius: var(--modal-br, var(--radius-box));
+      scale: 95%;
+      opacity: 0;
+      box-shadow: oklch(0% 0 0/ 0.25) 0px 25px 50px -12px;
+      overflow-y: auto;
+      overscroll-behavior: contain;
+    }
+  }
   .divider {
     @layer daisyui.l1.l2.l3 {
       display: flex;
@@ -2576,6 +2812,9 @@
   }
   .mt-5 {
     margin-top: calc(var(--spacing) * 5);
+  }
+  .mr-0 {
+    margin-right: calc(var(--spacing) * 0);
   }
   .mr-0\.5 {
     margin-right: calc(var(--spacing) * 0.5);
@@ -2805,6 +3044,9 @@
   .h-6 {
     height: calc(var(--spacing) * 6);
   }
+  .h-10 {
+    height: calc(var(--spacing) * 10);
+  }
   .h-12 {
     height: calc(var(--spacing) * 12);
   }
@@ -2813,6 +3055,9 @@
   }
   .h-full {
     height: 100%;
+  }
+  .max-h-52 {
+    max-height: calc(var(--spacing) * 52);
   }
   .max-h-90 {
     max-height: var(--spacing-90);
@@ -2904,11 +3149,17 @@
   .flex-1 {
     flex: 1;
   }
+  .flex-shrink {
+    flex-shrink: 1;
+  }
   .shrink {
     flex-shrink: 1;
   }
   .shrink-0 {
     flex-shrink: 0;
+  }
+  .flex-grow {
+    flex-grow: 1;
   }
   .grow {
     flex-grow: 1;
@@ -2916,12 +3167,19 @@
   .table-auto {
     table-layout: auto;
   }
+  .border-collapse {
+    border-collapse: collapse;
+  }
   .-translate-x-full {
     --tw-translate-x: -100%;
     translate: var(--tw-translate-x) var(--tw-translate-y);
   }
   .translate-x-0 {
     --tw-translate-x: calc(var(--spacing) * 0);
+    translate: var(--tw-translate-x) var(--tw-translate-y);
+  }
+  .translate-x-2 {
+    --tw-translate-x: calc(var(--spacing) * 2);
     translate: var(--tw-translate-x) var(--tw-translate-y);
   }
   .translate-x-2\.5 {
@@ -2954,6 +3212,22 @@
   }
   .transform-none {
     transform: none;
+  }
+  .skeleton {
+    @layer daisyui.l1.l2.l3 {
+      border-radius: var(--radius-box);
+      background-color: var(--color-base-300);
+      @media (prefers-reduced-motion: reduce) {
+        transition-duration: 15s;
+      }
+      will-change: background-position;
+      background-image: linear-gradient( 105deg, #0000 0% 40%, var(--color-base-100) 50%, #0000 60% 100% );
+      background-size: 200% auto;
+      background-position-x: -50%;
+      @media (prefers-reduced-motion: no-preference) {
+        animation: skeleton 1.8s ease-in-out infinite;
+      }
+    }
   }
   .link {
     @layer daisyui.l1.l2.l3 {
@@ -3109,6 +3383,10 @@
     border-style: var(--tw-border-style);
     border-width: 5px;
   }
+  .border-t {
+    border-top-style: var(--tw-border-style);
+    border-top-width: 1px;
+  }
   .border-none {
     --tw-border-style: none;
     border-style: none;
@@ -3120,6 +3398,9 @@
       background-image: none;
       border-color: currentColor;
     }
+  }
+  .border-base-200 {
+    border-color: var(--color-base-200);
   }
   .border-base-300 {
     border-color: var(--color-base-300);
@@ -3157,11 +3438,17 @@
   .bg-gray-100 {
     background-color: var(--color-gray-100);
   }
+  .bg-gray-900 {
+    background-color: var(--color-gray-900);
+  }
   .bg-gray-900\/50 {
     background-color: color-mix(in srgb, oklch(21% 0.034 264.665) 50%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
       background-color: color-mix(in oklab, var(--color-gray-900) 50%, transparent);
     }
+  }
+  .bg-info {
+    background-color: var(--color-info);
   }
   .bg-info\/15 {
     background-color: var(--color-info);
@@ -3205,8 +3492,17 @@
       mask-image: url("data:image/svg+xml,%3Csvg width='24' height='24' stroke='black' viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cg transform-origin='center'%3E%3Ccircle cx='12' cy='12' r='9.5' fill='none' stroke-width='3' stroke-linecap='round'%3E%3CanimateTransform attributeName='transform' type='rotate' from='0 12 12' to='360 12 12' dur='2s' repeatCount='indefinite'/%3E%3Canimate attributeName='stroke-dasharray' values='0,150;42,150;42,150' keyTimes='0;0.475;1' dur='1.5s' repeatCount='indefinite'/%3E%3Canimate attributeName='stroke-dashoffset' values='0;-16;-59' keyTimes='0;0.475;1' dur='1.5s' repeatCount='indefinite'/%3E%3C/circle%3E%3C/g%3E%3C/svg%3E");
     }
   }
+  .mask-repeat {
+    mask-repeat: repeat;
+  }
   .stroke-current {
     stroke: currentcolor;
+  }
+  .checkbox-sm {
+    @layer daisyui.l1.l2 {
+      padding: 0.1875rem;
+      --size: calc(var(--size-selector, 0.25rem) * 5);
+    }
   }
   .p-0 {
     padding: calc(var(--spacing) * 0);
@@ -3222,6 +3518,18 @@
   }
   .p-3 {
     padding: calc(var(--spacing) * 3);
+  }
+  .menu-title {
+    @layer daisyui.l1.l2.l3 {
+      padding-inline: calc(0.25rem * 3);
+      padding-block: calc(0.25rem * 2);
+      color: var(--color-base-content);
+      @supports (color: color-mix(in lab, red, red)) {
+        color: color-mix(in oklab, var(--color-base-content) 40%, transparent);
+      }
+      font-size: 0.875rem;
+      font-weight: 600;
+    }
   }
   .table-sm {
     @layer daisyui.l1.l2 {
@@ -3246,11 +3554,17 @@
   .px-4 {
     padding-inline: calc(var(--spacing) * 4);
   }
+  .px-5 {
+    padding-inline: calc(var(--spacing) * 5);
+  }
   .py-0 {
     padding-block: calc(var(--spacing) * 0);
   }
   .py-1 {
     padding-block: calc(var(--spacing) * 1);
+  }
+  .py-1\.5 {
+    padding-block: calc(var(--spacing) * 1.5);
   }
   .py-2 {
     padding-block: calc(var(--spacing) * 2);
@@ -3360,6 +3674,12 @@
       --input-color: var(--color-accent);
     }
   }
+  .checkbox-primary {
+    @layer daisyui.l1.l2 {
+      color: var(--color-primary-content);
+      --input-color: var(--color-primary);
+    }
+  }
   .link-accent {
     @layer daisyui.l1.l2 {
       color: var(--color-accent);
@@ -3391,6 +3711,12 @@
   }
   .text-base-content {
     color: var(--color-base-content);
+  }
+  .text-base-content\/40 {
+    color: var(--color-base-content);
+    @supports (color: color-mix(in lab, red, red)) {
+      color: color-mix(in oklab, var(--color-base-content) 40%, transparent);
+    }
   }
   .text-base-content\/60 {
     color: var(--color-base-content);
@@ -3466,6 +3792,10 @@
       --tw-shadow-color: color-mix(in oklab, var(--color-base-300) var(--tw-shadow-alpha), transparent);
     }
   }
+  .outline {
+    outline-style: var(--tw-outline-style);
+    outline-width: 1px;
+  }
   .btn-ghost {
     @layer daisyui.l1 {
       &:not(.btn-active, :hover, :active:focus, :focus-visible, input:checked:not(.filter .btn)) {
@@ -3497,6 +3827,11 @@
   .filter {
     filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
   }
+  .transition {
+    transition-property: color, background-color, border-color, outline-color, text-decoration-color, fill, stroke, --tw-gradient-from, --tw-gradient-via, --tw-gradient-to, opacity, box-shadow, transform, translate, scale, rotate, filter, -webkit-backdrop-filter, backdrop-filter, display, content-visibility, overlay, pointer-events;
+    transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
+    transition-duration: var(--tw-duration, var(--default-transition-duration));
+  }
   .transition-colors {
     transition-property: color, background-color, border-color, outline-color, text-decoration-color, fill, stroke, --tw-gradient-from, --tw-gradient-via, --tw-gradient-to;
     transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
@@ -3515,6 +3850,10 @@
   .duration-300 {
     --tw-duration: 300ms;
     transition-duration: 300ms;
+  }
+  .ease-in-out {
+    --tw-ease: var(--ease-in-out);
+    transition-timing-function: var(--ease-in-out);
   }
   .ease-out {
     --tw-ease: var(--ease-out);
@@ -3630,6 +3969,13 @@
     &:hover {
       @media (hover: hover) {
         border-color: var(--color-gray-300);
+      }
+    }
+  }
+  .hover\:bg-base-200 {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-base-200);
       }
     }
   }
@@ -4553,6 +4899,11 @@
   inherits: false;
   initial-value: 0 0 #0000;
 }
+@property --tw-outline-style {
+  syntax: "*";
+  inherits: false;
+  initial-value: solid;
+}
 @property --tw-blur {
   syntax: "*";
   inherits: false;
@@ -4642,6 +4993,7 @@
       --tw-ring-offset-width: 0px;
       --tw-ring-offset-color: #fff;
       --tw-ring-offset-shadow: 0 0 #0000;
+      --tw-outline-style: solid;
       --tw-blur: initial;
       --tw-brightness: initial;
       --tw-contrast: initial;

--- a/src/search_vulns/web_server_files/static/js/search_vulns.js
+++ b/src/search_vulns/web_server_files/static/js/search_vulns.js
@@ -45,6 +45,7 @@ function escapeCSV(text) {
         text = "'" + text;
     if (text.includes(',') || text.includes('"'))
         text = `"${text}"`;
+    text = text.replaceAll('\n', '\\n');
     return text;
 }
 
@@ -177,14 +178,17 @@ function createVulnTableRowHtml(idx, vuln) {
     var trackCount, vulnConfidence, source_badge_color = "", source_badge_icon = "", source_ref_icon = "";
     var badge_text_style = "", backgroundColorClass = "";
     var excludedVulnIDTypes = JSON.parse(localStorage.getItem('excludedVulnIDTypes'));
+    var hasNoVulnIDShown = true;
 
     if (selectedColumns.length < 1)
         return '';
 
     // set up references
     for (const vuln_id in vuln_id_ref_map) {
-        if (!excludedVulnIDTypes.some(vulnIDType => vuln_id.startsWith(vulnIDType)))
+        if (!excludedVulnIDTypes.some(vulnIDType => vuln_id.startsWith(vulnIDType))) {
             vuln_id_html += `<div class="w-full mb-0.3 max-md:whitespace-normal max-md:break-words"><a href="${htmlEntities(vuln_id_ref_map[vuln_id])}" target="_blank" style="color: inherit;">${htmlEntities(vuln_id)}&nbsp;&nbsp;<i class="fa-solid fa-up-right-from-square" style="font-size: 0.92rem"></i></a></div>`;
+            hasNoVulnIDShown = false;
+        }
     }
 
     // set up row highlighting
@@ -203,6 +207,9 @@ function createVulnTableRowHtml(idx, vuln) {
 
     vuln_row_html += `<tr class="${vuln_style_class} ${backgroundColorClass} border-none">`;
     if (selectedColumns.includes('cve')) {
+        if (hasNoVulnIDShown)
+            return "";
+
         vuln_row_html += `<td class="text-nowrap whitespace-nowrap relative pr-1 source-badge-cell align-top">` + vuln_id_html;
 
         // set up icons
@@ -416,7 +423,7 @@ function shouldVulnBeShownGenerally(vuln) {
 }
 
 function createNextVulnRowBatchHtml() {
-    var curBatchIdx = 0, vulnsHtml = "";
+    var curBatchIdx = 0, vulnsHtml = "", curVulnHtml = "";
     const excludedDataSources = JSON.parse(localStorage.getItem('excludedDataSources'));
     while (curBatchIdx < VULN_TABLE_ROW_BATCH_SIZE) {
         if (curVulnTableRowIndex < curVulnsSorted.length) {
@@ -430,8 +437,11 @@ function createNextVulnRowBatchHtml() {
                 continue;
             }
             if (onlyShowTheseVulns == null || onlyShowTheseVulns.includes(curVulnsSorted[curVulnTableRowIndex].id)) {
-                vulnsHtml += createVulnTableRowHtml(curVulnTableRowIndex, curVulnsSorted[curVulnTableRowIndex]);
-                curBatchIdx++;
+                curVulnHtml = createVulnTableRowHtml(curVulnTableRowIndex, curVulnsSorted[curVulnTableRowIndex]);
+                if (curVulnHtml.length > 0) {
+                    vulnsHtml += curVulnHtml;
+                    curBatchIdx++;
+                }
             }
             curVulnTableRowIndex++;
         }
@@ -625,7 +635,7 @@ function createVulnsMarkDownTable() {
     var selectedColumns = JSON.parse(localStorage.getItem('vulnTableColumns'));
     var vulns = getCurrentVulnsSorted(), vuln_id_ref_map;
     var vulns_md = "";
-    var has_exploits = false, cur_vuln_has_exploits = false;
+    var has_exploits = false, cur_vuln_has_exploits = false, vulnIDMarkdown = "";
     var cvss_score, cvss_version;
     var exploit_url_show;
     var excludedDataSources = JSON.parse(localStorage.getItem('excludedDataSources'));
@@ -712,12 +722,19 @@ function createVulnsMarkDownTable() {
         cur_vuln_has_exploits = false;
         vulns_md += '|';
         if (selectedColumns.length < 1 || selectedColumns.includes("cve")) {
+            vulnIDMarkdown = "";
             vuln_id_ref_map = vulns[i].aliases;
             for (const vuln_id in vuln_id_ref_map) {
                 if (!excludedVulnIDTypes.some(vulnIDType => vuln_id.startsWith(vulnIDType)))
-                    vulns_md += `[${vuln_id}](${htmlEntities(vuln_id_ref_map[vuln_id])})<br>`;
+                    vulnIDMarkdown += `[${vuln_id}](${htmlEntities(vuln_id_ref_map[vuln_id])})<br>`;
             }
-            vulns_md = vulns_md.slice(0, -4);  // strip trailing "<br>"
+            if (vulnIDMarkdown.length < 1) {
+                vulns_md = vulns_md.slice(0, -1);  // remove already opened row '|'
+                continue;
+            }
+
+            vulnIDMarkdown = vulnIDMarkdown.slice(0, -4);  // strip trailing "<br>"
+            vulns_md += vulnIDMarkdown;
             vulns_md += "|";
         }
         if (selectedColumns.length < 1 || selectedColumns.includes("cvss")) {
@@ -863,8 +880,10 @@ function createVulnsCSV() {
                 if (!excludedVulnIDTypes.some(vulnIDType => vuln_id.startsWith(vulnIDType)))
                     vuln_ids.push(vuln_id);
             }
-            if (vuln_ids)
+            if (vuln_ids.length > 0)
                 vulns_csv += `${escapeCSV(vuln_ids.join(', '))}`
+            else
+                continue;
             vulns_csv += ','
         }
         if (selectedColumns.length < 1 || selectedColumns.includes("cvss")) {

--- a/src/search_vulns/web_server_files/static/js/search_vulns.js
+++ b/src/search_vulns/web_server_files/static/js/search_vulns.js
@@ -1,5 +1,5 @@
 
-var curVulnData = {}, curEOLData = {}, onlyShowTheseVulns = null;
+var curVulnData = {}, curVulnsSorted = [], curEOLData = {}, onlyShowTheseVulns = null;
 var exploit_url_show_max_length = 52, exploit_url_show_max_length_md = 42;
 var ignoreGeneralProductVulns = false, onlyShowEDBExploits = false;
 var showSingleVersionVulns = false, isGoodProductID = true, showPatchedVulns = true;
@@ -14,8 +14,9 @@ var curSortColIdx = 1, curSortColAsc = false, searchIgnoreNextKeyup = false;
 var doneTypingQueryTimer, queryInput = $('#query'), doneTypingQueryInterval = 600;  //time in ms
 var arrowKeyUpDownInterval = null, arrowKeyUpDownIntervalTime = 100, arrowKeyUpDownHoldDetectionTimer = null, arrowKeyUpDownHoldDetectionTime = 150;
 var curSelectedProductIDSuggestion = -1, suggestedQueriesJustOpened = false;
-var minMatchScore = 0;
+var minMatchScore = 0, curVulnTableRowIndex = 0;
 const IS_VULN_ID_QUERY_RE = /\b[A-Z]{2,10}(?:-[A-Z0-9]{2,12}){1,4}\b/;
+const VULN_TABLE_ROW_BATCH_SIZE = 100;
 
 
 function htmlEntities(text) {
@@ -402,6 +403,43 @@ function resizeSearchVulnsTable() {
     }
 }
 
+function shouldVulnBeShownGenerally(vuln) {
+    if (ignoreGeneralProductVulns && vuln.match_reason == "general_product_uncertain")
+        return false;
+    if (!showSingleVersionVulns && vuln.match_reason == "single_higher_version")
+        return false;
+    if (!showPatchedVulns && vuln.reported_patched_by.length > 0)
+        return false;
+    if (computeVulnMatchScore(vuln) < minMatchScore)
+        return false;
+    return true;
+}
+
+function createNextVulnRowBatchHtml() {
+    var curBatchIdx = 0, vulnsHtml = "";
+    const excludedDataSources = JSON.parse(localStorage.getItem('excludedDataSources'));
+    while (curBatchIdx < VULN_TABLE_ROW_BATCH_SIZE) {
+        if (curVulnTableRowIndex < curVulnsSorted.length) {
+            // skip vuln if configured
+            if (!shouldVulnBeShownGenerally(curVulnsSorted[curVulnTableRowIndex])) {
+                curVulnTableRowIndex++;
+                continue;
+            }
+            if (Object.keys(curVulnsSorted[curVulnTableRowIndex].matched_by).every(data_source => excludedDataSources.includes(data_source))) {
+                curVulnTableRowIndex++;
+                continue;
+            }
+            if (onlyShowTheseVulns == null || onlyShowTheseVulns.includes(curVulnsSorted[curVulnTableRowIndex].id)) {
+                vulnsHtml += createVulnTableRowHtml(curVulnTableRowIndex, curVulnsSorted[curVulnTableRowIndex]);
+                curBatchIdx++;
+            }
+            curVulnTableRowIndex++;
+        }
+        else
+            break
+    }
+    return vulnsHtml;
+}
 
 function renderSearchResults(sourceFilterID) {
     var sortIconVulnId = iconUnsorted, sortFunctionVulnId = "reorderVulns(0, false)";
@@ -410,7 +448,7 @@ function renderSearchResults(sourceFilterID) {
     var sortIconExploits = iconUnsorted, sortFunctionExploits = "reorderVulns(4, false)";
 
     // retrieve and sort vulns
-    var vulns = getCurrentVulnsSorted();
+    curVulnsSorted = getCurrentVulnsSorted();
     if (curSortColIdx == 0) {  // Vuln ID
         if (curSortColAsc) {
             sortIconVulnId = iconSortAsc;
@@ -480,41 +518,36 @@ function renderSearchResults(sourceFilterID) {
         vulns_html += `<th class="bg-base-300" onclick="${sortFunctionExploits}" style="white-space: nowrap;">Exploits&nbsp;&nbsp;${sortIconExploits}</th>`;
     }
     vulns_html += "</tr></thead>";
-    vulns_html += "<tbody>";
+    vulns_html += `<tbody id="vulns-tbody">`;
 
     var filter_vulns_html = filterVulnDropdownButtonHtml, has_vulns = false;
     var involved_data_sources = new Set(), allVulnIDTypes = new Set();
     var excludedDataSources = JSON.parse(localStorage.getItem('excludedDataSources'));
     var hiddenVulnsViaDataSources, hiddenVulnViaFilter = false, hiddenVulnViaFilter=false;
-    for (var i = 0; i < vulns.length; i++) {
+    curVulnTableRowIndex = 0;
+    for (var i = 0; i < curVulnsSorted.length; i++) {
         // append involved data sources
-        for (const data_source of Object.keys(vulns[i].tracked_by)) {
+        for (const data_source of Object.keys(curVulnsSorted[i].tracked_by)) {
             involved_data_sources.add(data_source);
         }
 
         // append involved vuln ID types, assume a dash format
-        Object.keys(vulns[i].aliases).forEach(vulnID => {
+        Object.keys(curVulnsSorted[i].aliases).forEach(vulnID => {
             allVulnIDTypes.add(vulnID.slice(0, vulnID.indexOf("-") + 1))
         });
 
-        // create row in table
-        if (ignoreGeneralProductVulns && vulns[i].match_reason == "general_product_uncertain")
+        // skip vuln if configured
+        if (!shouldVulnBeShownGenerally(curVulnsSorted[i]))
             continue;
-        if (!showSingleVersionVulns && vulns[i].match_reason == "single_higher_version")
-            continue;
-        if (!showPatchedVulns && vulns[i].reported_patched_by.length > 0)
-            continue;
-        if (computeVulnMatchScore(vulns[i]) < minMatchScore)
-            continue;
-        if (Object.keys(vulns[i].matched_by).every(data_source => excludedDataSources.includes(data_source))) {
+        if (Object.keys(curVulnsSorted[i].matched_by).every(data_source => excludedDataSources.includes(data_source))) {
             hiddenVulnsViaDataSources = true;
             continue;
         }
 
+        // extract secondary information
         has_vulns = true;
         var checked_html = "", margin_html = "";
-        if (onlyShowTheseVulns == null || onlyShowTheseVulns.includes(vulns[i].id)) {
-            vulns_html += createVulnTableRowHtml(i, vulns[i]);
+        if (onlyShowTheseVulns == null || onlyShowTheseVulns.includes(curVulnsSorted[i].id)) {
             checked_html = 'checked="checked"';
         }
         if (!checked_html)
@@ -523,8 +556,11 @@ function renderSearchResults(sourceFilterID) {
             margin_html = "mt-3"
 
         // add Vuln ID to filter
-        filter_vulns_html += `<div class="form-control filter-vulns ${margin_html}"><label class="label cursor-pointer flex items-center gap-4 min-w-0 text-sm"><span class="label-text text-nowrap whitespace-nowrap text-base-content flex-1 min-w-0 text-left">${vulns[i]["id"]}</span><input type="checkbox" class="checkbox checkbox-accent rounded-md shrink-0" onclick="changeFilterVulns()" ${checked_html} /></label></div>`;
+        filter_vulns_html += `<div class="form-control filter-vulns ${margin_html}"><label class="label cursor-pointer flex items-center gap-4 min-w-0 text-sm"><span class="label-text text-nowrap whitespace-nowrap text-base-content flex-1 min-w-0 text-left">${curVulnsSorted[i]["id"]}</span><input type="checkbox" class="checkbox checkbox-accent rounded-md shrink-0" onclick="changeFilterVulns()" ${checked_html} /></label></div>`;
     }
+
+    // get HTML for vuln row batch and add it to table
+    vulns_html += createNextVulnRowBatchHtml();
     vulns_html += "</tbody></table>";
 
     // update vuln data sources filter
@@ -552,11 +588,18 @@ function renderSearchResults(sourceFilterID) {
     // update vuln ID type configuration
     if (sourceFilterID != "excludedVulnIDTypes") {
         renderVulnIDTypesSelectionOptions(allVulnIDTypes);
-        rerenderOnVulnIDTypesSelection([... allVulnIDTypes]);
+        rerenderOnVulnIDTypesSelection([... allVulnIDTypes], false);
     }
 
     if (has_vulns) {
-        $("#vulns").html(vulns_html);
+        // use Template/DocumentFragment for faster operation than jQuery's .html
+        const template = document.createElement('template');
+        template.innerHTML = vulns_html;
+
+        const container = document.getElementById('vulns');
+        container.innerHTML = '';
+        container.appendChild(template.content);
+
         // wait for next animation frame and the resize table with the dynamic source badge
         requestAnimationFrame(() => {
             resizeSearchVulnsTable();
@@ -1594,7 +1637,7 @@ function closeVulnIDTypesSelection() {
     document.getElementById('vuln-ids-config-ms-arrow').style.transform = '';
 }
 
-function rerenderOnVulnIDTypesSelection(allTypes) {
+function rerenderOnVulnIDTypesSelection(allTypes, rerenderVulns) {
     const excludedTypes = JSON.parse(localStorage.getItem("excludedVulnIDTypes"));
     const shownTypes = allTypes.filter(type => !excludedTypes.includes(type));
     const placeholder = document.getElementById('vuln-ids-config-ms-ph');
@@ -1604,7 +1647,7 @@ function rerenderOnVulnIDTypesSelection(allTypes) {
         : 'Pick ID Types ...';
     placeholder.className = `flex-1 ${shownTypes.length ? 'text-base-content' : 'text-base-content/40'}`;
 
-    if (!$.isEmptyObject(curVulnData)) {
+    if (!$.isEmptyObject(curVulnData) && rerenderVulns) {
         var hasVulns = renderSearchResults("excludedVulnIDTypes");
         if (!hasVulns)
             $('#vulns').html(noVulnsFoundHtml);
@@ -1642,7 +1685,7 @@ function renderVulnIDTypesSelectionOptions(curShownTypes) {
                 newExcluded.push(type);
             localStorage.setItem("excludedVulnIDTypes", JSON.stringify([...newExcluded]));
 
-            rerenderOnVulnIDTypesSelection(allTypes);
+            rerenderOnVulnIDTypesSelection(allTypes, true);
         });
         label.appendChild(document.createTextNode(type));
         label.appendChild(checkbox);
@@ -1667,7 +1710,28 @@ function vulnIDTypesSelectionAllNone(all) {
         }
     });
     localStorage.setItem("excludedVulnIDTypes", JSON.stringify(excludedVulnIDTypes));
-    rerenderOnVulnIDTypesSelection(allTypes);
+    rerenderOnVulnIDTypesSelection(allTypes, true);
+}
+
+function loadMoreVulnRows() {
+    if (curVulnsSorted.length > 0) {
+        // load more rows HTML
+        const vulnsHtml = createNextVulnRowBatchHtml();
+
+        const template = document.createElement('template');
+        template.innerHTML = vulnsHtml;
+
+        const tbody = document.getElementById('vulns-tbody');
+        tbody.appendChild(template.content);
+
+        // wait for next animation frame and the resize table with the dynamic source badge
+        requestAnimationFrame(() => {
+            resizeSearchVulnsTable();
+        });
+
+        initFlowbite();
+        fixDropdownClicking();
+    }
 }
 
 
@@ -1803,4 +1867,16 @@ window.addEventListener("popstate", (event) => {
         $("#vulns").html("");
         $("#related-queries-display").html("");
     }
+});
+
+// enable infinite scroll for vuln tables
+window.addEventListener('scroll', function () {
+    const tbody = document.getElementById('vulns-tbody');
+    if (tbody == null)
+        return;
+
+    // load more vulns when the table bottom is within 300px of the viewport bottom
+    const tbodyBottom = tbody.getBoundingClientRect().bottom;
+    if (tbodyBottom - window.innerHeight < 300)
+        loadMoreVulnRows();
 });

--- a/src/search_vulns/web_server_files/static/js/search_vulns.js
+++ b/src/search_vulns/web_server_files/static/js/search_vulns.js
@@ -1298,6 +1298,7 @@ function onMinMatchScoreSliderChange(slider) {
 }
 
 function setupConfigFromLocalstorage() {
+    // init default settings
     if (localStorage.getItem('ignoreGeneralProductVulns') === null) {
         localStorage.setItem('ignoreGeneralProductVulns', 'false');
     }
@@ -1317,6 +1318,7 @@ function setupConfigFromLocalstorage() {
         localStorage.setItem('excludedDataSources', "[]");
     }
 
+    // get configuration from local storage and adjust UI and internal state
     if (localStorage.getItem('ignoreGeneralProductVulns') == 'true') {
         ignoreGeneralProductVulns = true;
         document.getElementById("generalVulnsConfig").checked = true;
@@ -1328,7 +1330,7 @@ function setupConfigFromLocalstorage() {
         document.getElementById("onlyEdbExploitsConfig").checked = true;
     }
     else
-        onlyShowEDBExploits = true;
+        onlyShowEDBExploits = false;
     if (localStorage.getItem('showSingleVersionVulns') == 'true') {
         showSingleVersionVulns = true;
         document.getElementById("showSingleVersionVulnsConfig").checked = true;

--- a/src/search_vulns/web_server_files/static/js/search_vulns.js
+++ b/src/search_vulns/web_server_files/static/js/search_vulns.js
@@ -291,7 +291,7 @@ function createVulnTableRowHtml(idx, vuln) {
 
     if (selectedColumns.includes('cvss')) {
         cvss_vector = "N/A";
-        cvss= "N/A";
+        cvss = "N/A";
         cvss_badge_css = "";
 
         if (vuln.severity.hasOwnProperty("CVSS")) {
@@ -495,7 +495,7 @@ function renderSearchResults(sourceFilterID) {
         $("#vulns").html('');
         return false;
     }
-    
+
     vulns_html = '<table class="table table-mdsm sv-vuln-table-zebra table-rounded table-auto invisible">';
     vulns_html += '<thead>';
     vulns_html += '<tr>'
@@ -523,7 +523,7 @@ function renderSearchResults(sourceFilterID) {
     var filter_vulns_html = filterVulnDropdownButtonHtml, has_vulns = false;
     var involved_data_sources = new Set(), allVulnIDTypes = new Set();
     var excludedDataSources = JSON.parse(localStorage.getItem('excludedDataSources'));
-    var hiddenVulnsViaDataSources, hiddenVulnViaFilter = false, hiddenVulnViaFilter=false;
+    var hiddenVulnsViaDataSources, hiddenVulnViaFilter = false, hiddenVulnViaFilter = false;
     curVulnTableRowIndex = 0;
     for (var i = 0; i < curVulnsSorted.length; i++) {
         // append involved data sources
@@ -588,7 +588,7 @@ function renderSearchResults(sourceFilterID) {
     // update vuln ID type configuration
     if (sourceFilterID != "excludedVulnIDTypes") {
         renderVulnIDTypesSelectionOptions(allVulnIDTypes);
-        rerenderOnVulnIDTypesSelection([... allVulnIDTypes], false);
+        rerenderOnVulnIDTypesSelection([...allVulnIDTypes], false);
     }
 
     if (has_vulns) {
@@ -941,7 +941,7 @@ function buildTextualReprFromCPE(cpe) {
     cpe_parts.slice(7).forEach(cpe_part => {
         if (cpe_part && cpe_part != '-' && cpe_part != '*') {
             var cpe_part = cpe_part[0].toUpperCase() + cpe_part.substring(1);
-            cpe_condition += cpe_part.split('_').map(w => w ? w[0].toUpperCase() + w.substring(1).toLowerCase(): '').join(' ') + ' ';
+            cpe_condition += cpe_part.split('_').map(w => w ? w[0].toUpperCase() + w.substring(1).toLowerCase() : '').join(' ') + ' ';
         }
     });
 
@@ -958,7 +958,7 @@ function buildTextualReprFromCPE(cpe) {
 function searchVulns(query, product_id, url_query, recaptcha_response) {
     var headers = {}
     if (recaptcha_response !== undefined)
-        headers = {'Recaptcha-Response': recaptcha_response}
+        headers = { 'Recaptcha-Response': recaptcha_response }
 
     var apiKey = localStorage.getItem('apiKey');
     if (apiKey !== undefined && apiKey !== null && apiKey)
@@ -1001,7 +1001,7 @@ function searchVulns(query, product_id, url_query, recaptcha_response) {
                         search_display_html += `)`;
                     }
                     search_display_html += `</h5></div></div>`;
-                    curEOLData = {'query': query, 'version_status': search_results.version_status};
+                    curEOLData = { 'query': query, 'version_status': search_results.version_status };
                     if (search_results.version_status) {
                         if (search_results.version_status.status == 'EOL') {
                             search_display_html += `<div class="row mt-1 mb-3 text-warning text-smxs font-light">${htmlEntities(query)} is end of life. The latest version is ${htmlEntities(search_results.version_status.latest)} (see <a class="link" target="_blank" href="${htmlEntities(search_results.version_status.reference)}">here</a>).<span class="ml-2 text-base-content"><button class="btn btn-sm btn-copy-md align-middle" onclick="copyToClipboardEOLProof(this)"><i class="fa-brands fa-markdown"></i></button></span></div>`;
@@ -1097,8 +1097,8 @@ function searchVulnsFromState(state) {
     curEOLData = {};
 
     if (typeof grecaptcha !== 'undefined') {
-        grecaptcha.ready(function() {
-            grecaptcha.execute().then(function(recaptcha_response) {
+        grecaptcha.ready(function () {
+            grecaptcha.execute().then(function (recaptcha_response) {
                 searchVulns(state.query, state.productID, state.url_query, recaptcha_response);
             });
         });
@@ -1180,7 +1180,7 @@ function copyToClipboardEOLProof(clickedButton) {
     // indicate success
     $(clickedButton).removeClass('text-base-content');
     $(clickedButton).addClass('text-success');
-    setTimeout(function() {
+    setTimeout(function () {
         $(clickedButton).removeClass('text-success');
         $(clickedButton).addClass('text-base-content');
     }, 1750);
@@ -1204,7 +1204,7 @@ function copyToClipboardCVSS(cvssClipboardButton) {
 }
 
 function clearQuery() {
-    document.getElementById('query').value='';
+    document.getElementById('query').value = '';
     document.getElementById('query').focus();
 }
 
@@ -1249,7 +1249,7 @@ function changeColumnConfig(columnElement) {
 
     if (allCheckType != null) {
         columnCheckboxIDs = ['showColumnVulnId', 'showColumnCVSS', 'showColumnEPSS', 'showColumnCWE', 'showColumnDescription', 'showColumnExploits'];
-        columnCheckboxIDs.forEach(function(columnCheckboxID) {
+        columnCheckboxIDs.forEach(function (columnCheckboxID) {
             $('#' + columnCheckboxID)[0].checked = allCheckType;
         });
     }
@@ -1278,7 +1278,7 @@ function changeFilterVulns(filterVulnsButton) {
     var allOrNone = '';
 
     if (filterVulnsButton != null) {
-        if(filterVulnsButton.id == 'filterVulnsNone')
+        if (filterVulnsButton.id == 'filterVulnsNone')
             allOrNone = 'none';
         else {
             onlyShowTheseVulns = null;
@@ -1286,7 +1286,7 @@ function changeFilterVulns(filterVulnsButton) {
         }
     }
 
-    $('.filter-vulns').each(function(i, filterVulnsDiv) {
+    $('.filter-vulns').each(function (i, filterVulnsDiv) {
         filterVulnsDiv = $(filterVulnsDiv);
         if (allOrNone == 'none')
             filterVulnsDiv.find('.checkbox')[0].checked = false;
@@ -1342,8 +1342,8 @@ function changeDataSourcesConfig(dataSourcesElement) {
 
     if (!$.isEmptyObject(curVulnData))
         var hasVulns = renderSearchResults("filterDataSourcesDropdown");
-        if (!hasVulns)
-            $('#vulns').html(noVulnsFoundHtml);
+    if (!hasVulns)
+        $('#vulns').html(noVulnsFoundHtml);
 }
 
 function onMinMatchScoreSliderInput(slider) {
@@ -1455,8 +1455,8 @@ function initQuery() {
 }
 
 function fixDropdownClicking() {
-    $('.dropdown').find('.btn:first').on('mousedown', function(event) {
-        var closestDropdown = document.activeElement.closest('.dropdown') 
+    $('.dropdown').find('.btn:first').on('mousedown', function (event) {
+        var closestDropdown = document.activeElement.closest('.dropdown')
         if (closestDropdown !== null && closestDropdown == event.target.closest('.dropdown')) {
             event.preventDefault();
             document.activeElement.blur();
@@ -1549,7 +1549,7 @@ function retrieveProductIDSuggestions(url_query, recaptcha_response) {
     });
 }
 
-function doneTypingQuery () {
+function doneTypingQuery() {
     // user paused or finished typing query --> retrieve and show product ID suggestions
     $('#productIDSuggestions').html('Searching for products and IDs<div class="loading loading-spinner ml-2"></div>');
     $('#productIDSuggestions').removeClass('hidden');
@@ -1559,7 +1559,7 @@ function doneTypingQuery () {
         query = '';
 
     // no product ID suggestions for vuln IDs search
-    if (IS_VULN_ID_QUERY_RE.test(query.trim())){
+    if (IS_VULN_ID_QUERY_RE.test(query.trim())) {
         var dropdownContent = `<ul class="menu menu-md p-1 bg-base-200 rounded-box w-full"><li tabindex="0"><a class="text-nowrap whitespace-nowrap" id="product-id-suggestion-0" onclick="searchVulnsAction(this)">${query.trim()}</a></li></ul>`;
         $('#productIDSuggestions').html(dropdownContent);
         return;
@@ -1569,8 +1569,8 @@ function doneTypingQuery () {
     var url_query = "query=" + queryEnc;
 
     if (typeof grecaptcha !== 'undefined') {
-        grecaptcha.ready(function() {
-            grecaptcha.execute().then(function(recaptcha_response) {
+        grecaptcha.ready(function () {
+            grecaptcha.execute().then(function (recaptcha_response) {
                 retrieveProductIDSuggestions(url_query, recaptcha_response);
             });
         });
@@ -1835,7 +1835,7 @@ queryInput.on('keydown', function (event) {
             }
         }
         // any key except CTRL, OPTION, CMD/SUPER/Windows
-        else if(![13, 17, 18, 37, 39, 91, 229].includes(event.keyCode)) {
+        else if (![13, 17, 18, 37, 39, 91, 229].includes(event.keyCode)) {
             clearTimeout(doneTypingQueryTimer);
             $('#productIDSuggestions').addClass("hidden");
             $('#productIDSuggestions').html("");

--- a/src/search_vulns/web_server_files/static/js/search_vulns.js
+++ b/src/search_vulns/web_server_files/static/js/search_vulns.js
@@ -175,13 +175,15 @@ function createVulnTableRowHtml(idx, vuln) {
     var selectedColumns = JSON.parse(localStorage.getItem('vulnTableColumns'))
     var trackCount, vulnConfidence, source_badge_color = "", source_badge_icon = "", source_ref_icon = "";
     var badge_text_style = "", backgroundColorClass = "";
+    var excludedVulnIDTypes = JSON.parse(localStorage.getItem('excludedVulnIDTypes'));
 
     if (selectedColumns.length < 1)
         return '';
 
     // set up references
     for (const vuln_id in vuln_id_ref_map) {
-        vuln_id_html += `<div class="w-full mb-0.3 max-md:whitespace-normal max-md:break-words"><a href="${htmlEntities(vuln_id_ref_map[vuln_id])}" target="_blank" style="color: inherit;">${htmlEntities(vuln_id)}&nbsp;&nbsp;<i class="fa-solid fa-up-right-from-square" style="font-size: 0.92rem"></i></a></div>`;
+        if (!excludedVulnIDTypes.some(vulnIDType => vuln_id.startsWith(vulnIDType)))
+            vuln_id_html += `<div class="w-full mb-0.3 max-md:whitespace-normal max-md:break-words"><a href="${htmlEntities(vuln_id_ref_map[vuln_id])}" target="_blank" style="color: inherit;">${htmlEntities(vuln_id)}&nbsp;&nbsp;<i class="fa-solid fa-up-right-from-square" style="font-size: 0.92rem"></i></a></div>`;
     }
 
     // set up row highlighting
@@ -481,7 +483,7 @@ function renderSearchResults(sourceFilterID) {
     vulns_html += "<tbody>";
 
     var filter_vulns_html = filterVulnDropdownButtonHtml, has_vulns = false;
-    var involved_data_sources = new Set();
+    var involved_data_sources = new Set(), allVulnIDTypes = new Set();
     var excludedDataSources = JSON.parse(localStorage.getItem('excludedDataSources'));
     var hiddenVulnsViaDataSources, hiddenVulnViaFilter = false, hiddenVulnViaFilter=false;
     for (var i = 0; i < vulns.length; i++) {
@@ -489,6 +491,11 @@ function renderSearchResults(sourceFilterID) {
         for (const data_source of Object.keys(vulns[i].tracked_by)) {
             involved_data_sources.add(data_source);
         }
+
+        // append involved vuln ID types, assume a dash format
+        Object.keys(vulns[i].aliases).forEach(vulnID => {
+            allVulnIDTypes.add(vulnID.slice(0, vulnID.indexOf("-") + 1))
+        });
 
         // create row in table
         if (ignoreGeneralProductVulns && vulns[i].match_reason == "general_product_uncertain")
@@ -520,6 +527,7 @@ function renderSearchResults(sourceFilterID) {
     }
     vulns_html += "</tbody></table>";
 
+    // update vuln data sources filter
     var filter_data_sources_html = filterDataSourcesDropdownButtonHtml;
     var checked_html = "", margin_html = "";
     for (const data_source of [...involved_data_sources].sort()) {
@@ -540,6 +548,12 @@ function renderSearchResults(sourceFilterID) {
         document.getElementById("vulnFilterHiddenVulnsNotifier").classList.remove("hidden");
     else
         document.getElementById("vulnFilterHiddenVulnsNotifier").classList.add("hidden");
+
+    // update vuln ID type configuration
+    if (sourceFilterID != "excludedVulnIDTypes") {
+        renderVulnIDTypesSelectionOptions(allVulnIDTypes);
+        rerenderOnVulnIDTypesSelection([... allVulnIDTypes]);
+    }
 
     if (has_vulns) {
         $("#vulns").html(vulns_html);
@@ -572,6 +586,7 @@ function createVulnsMarkDownTable() {
     var cvss_score, cvss_version;
     var exploit_url_show;
     var excludedDataSources = JSON.parse(localStorage.getItem('excludedDataSources'));
+    var excludedVulnIDTypes = JSON.parse(localStorage.getItem('excludedVulnIDTypes'));
 
     for (var i = 0; i < vulns.length; i++) {
         if (selectedVulns != null && selectedVulns.length > 0 && !selectedVulns.includes(vulns[i]["id"]))
@@ -656,7 +671,8 @@ function createVulnsMarkDownTable() {
         if (selectedColumns.length < 1 || selectedColumns.includes("cve")) {
             vuln_id_ref_map = vulns[i].aliases;
             for (const vuln_id in vuln_id_ref_map) {
-                vulns_md += `[${vuln_id}](${htmlEntities(vuln_id_ref_map[vuln_id])})<br>`;
+                if (!excludedVulnIDTypes.some(vulnIDType => vuln_id.startsWith(vulnIDType)))
+                    vulns_md += `[${vuln_id}](${htmlEntities(vuln_id_ref_map[vuln_id])})<br>`;
             }
             vulns_md = vulns_md.slice(0, -4);  // strip trailing "<br>"
             vulns_md += "|";
@@ -734,6 +750,7 @@ function createVulnsCSV() {
     var cvss_score, cvss_version;
     var has_exploits = false;
     var excludedDataSources = JSON.parse(localStorage.getItem('excludedDataSources'));
+    var excludedVulnIDTypes = JSON.parse(localStorage.getItem('excludedVulnIDTypes'));
 
     for (var i = 0; i < vulns.length; i++) {
         if (selectedVulns != null && selectedVulns.length > 0 && !selectedVulns.includes(vulns[i]["id"]))
@@ -800,7 +817,8 @@ function createVulnsCSV() {
             vuln_id_ref_map = vulns[i].aliases;
             vuln_ids = [];
             for (const vuln_id in vuln_id_ref_map) {
-                vuln_ids.push(vuln_id);
+                if (!excludedVulnIDTypes.some(vulnIDType => vuln_id.startsWith(vulnIDType)))
+                    vuln_ids.push(vuln_id);
             }
             if (vuln_ids)
                 vulns_csv += `${escapeCSV(vuln_ids.join(', '))}`
@@ -1297,7 +1315,7 @@ function onMinMatchScoreSliderChange(slider) {
         renderSearchResults();
 }
 
-function setupConfigFromLocalstorage() {
+function setUpConfigFromLocalstorage() {
     // init default settings
     if (localStorage.getItem('ignoreGeneralProductVulns') === null) {
         localStorage.setItem('ignoreGeneralProductVulns', 'false');
@@ -1316,6 +1334,9 @@ function setupConfigFromLocalstorage() {
     }
     if (localStorage.getItem('excludedDataSources') === null) {
         localStorage.setItem('excludedDataSources', "[]");
+    }
+    if (localStorage.getItem('excludedVulnIDTypes') === null) {
+        localStorage.setItem('excludedVulnIDTypes', "[]");
     }
 
     // get configuration from local storage and adjust UI and internal state
@@ -1536,26 +1557,6 @@ function ensureSuggestionVisible(suggestionElement) {
     }
 }
 
-
-/* init */
-
-// enables the user to press return on the query text field to make the query
-$("#query").keypress(function (event) {
-    var keycode = (event.keyCode ? event.keyCode : event.which);
-    if (keycode == "13") {
-        if (!$("#productIDSuggestions").hasClass("hidden")) {
-            var highlightedProductIDSuggestion = null;
-            if ($("#productIDSuggestions").find('ul').length > 0) {
-                highlightedProductIDSuggestion = $("#productIDSuggestions").find('.my-menu-item-hover');
-                if (!highlightedProductIDSuggestion || curSelectedProductIDSuggestion == -1)
-                    searchVulnsAction();
-                else
-                    document.getElementById('product-id-suggestion-' + curSelectedProductIDSuggestion).click();
-            }
-        }
-    }
-});
-
 function moveProductIDSuggestionUpDown(event) {
     // move currently selected product ID suggestion up or down depending on event
     if (curSelectedProductIDSuggestion > -1)
@@ -1579,6 +1580,115 @@ function moveProductIDSuggestionUpDown(event) {
     }
 }
 
+function openVulnIDTypesSelection() {
+    const dropdown = document.getElementById('vuln-ids-config-ms-dropdown');
+    isVulnIDTypesSelectionOpen = true;
+    dropdown.classList.remove('hidden');
+    document.getElementById('vuln-ids-config-ms-arrow').style.transform = 'rotate(180deg)';
+}
+
+function closeVulnIDTypesSelection() {
+    const dropdown = document.getElementById('vuln-ids-config-ms-dropdown');
+    isVulnIDTypesSelectionOpen = false;
+    dropdown.classList.add('hidden');
+    document.getElementById('vuln-ids-config-ms-arrow').style.transform = '';
+}
+
+function rerenderOnVulnIDTypesSelection(allTypes) {
+    const excludedTypes = JSON.parse(localStorage.getItem("excludedVulnIDTypes"));
+    const shownTypes = allTypes.filter(type => !excludedTypes.includes(type));
+    const placeholder = document.getElementById('vuln-ids-config-ms-ph');
+    // show 2 vuln ID types max
+    placeholder.textContent = shownTypes.length
+        ? shownTypes.slice(0, 2).join(', ') + (shownTypes.length > 2 ? ` +${shownTypes.length - 2}` : '')
+        : 'Pick ID Types ...';
+    placeholder.className = `flex-1 ${shownTypes.length ? 'text-base-content' : 'text-base-content/40'}`;
+
+    if (!$.isEmptyObject(curVulnData)) {
+        var hasVulns = renderSearchResults("excludedVulnIDTypes");
+        if (!hasVulns)
+            $('#vulns').html(noVulnsFoundHtml);
+    }
+}
+
+function renderVulnIDTypesSelectionOptions(curShownTypes) {
+    let excludedVulnIDTypes = JSON.parse(localStorage.getItem('excludedVulnIDTypes'));
+    let allTypes = excludedVulnIDTypes;
+    if (curShownTypes != undefined) {
+        allTypes = [...new Set([...allTypes, ...curShownTypes])].sort();
+    }
+
+    const vulnIDTypesMS = document.getElementById('vuln-ids-config-ms-opts');
+    vulnIDTypesMS.innerHTML = '';
+    if (allTypes.length < 1) {
+        vulnIDTypesMS.innerHTML = '<div class="py-2 text-sm">Please search first.</div>'
+    }
+    allTypes.forEach(type => {
+        const li = document.createElement('li');
+        const label = document.createElement('label');
+        const checkbox = document.createElement('input');
+
+        label.className = 'flex items-center justify-between px-3 py-2 w-full cursor-pointer hover:bg-base-200 text-sm';
+        checkbox.type = 'checkbox';
+        checkbox.className = 'checkbox checkbox-sm checkbox-primary';
+        checkbox.checked = !excludedVulnIDTypes.includes(type);
+        checkbox.addEventListener('change', () => {
+            let newExcluded = JSON.parse(localStorage.getItem('excludedVulnIDTypes'));
+            if (checkbox.checked)
+                // remove from excluded vuln ID types
+                newExcluded = newExcluded.filter(item => item !== type);
+            else
+                // add to excluded vuln ID types
+                newExcluded.push(type);
+            localStorage.setItem("excludedVulnIDTypes", JSON.stringify([...newExcluded]));
+
+            rerenderOnVulnIDTypesSelection(allTypes);
+        });
+        label.appendChild(document.createTextNode(type));
+        label.appendChild(checkbox);
+        li.appendChild(label);
+        vulnIDTypesMS.appendChild(li);
+    });
+}
+
+function vulnIDTypesSelectionAllNone(all) {
+    const vulnIDTypesMS = document.getElementById('vuln-ids-config-ms-opts');
+    const labels = vulnIDTypesMS.querySelectorAll("li label");
+    let excludedVulnIDTypes = [], allTypes = [];
+    labels.forEach(label => {
+        let vulnIDType = label.childNodes[0].textContent.trim();
+        allTypes.push(vulnIDType);
+        const checkbox = label.querySelector("input[type='checkbox']");
+        if (all)
+            checkbox.checked = true;
+        else {
+            checkbox.checked = false;
+            excludedVulnIDTypes.push(vulnIDType);
+        }
+    });
+    localStorage.setItem("excludedVulnIDTypes", JSON.stringify(excludedVulnIDTypes));
+    rerenderOnVulnIDTypesSelection(allTypes);
+}
+
+
+/* init */
+
+// enables the user to press return on the query text field to make the query
+$("#query").keypress(function (event) {
+    var keycode = (event.keyCode ? event.keyCode : event.which);
+    if (keycode == "13") {
+        if (!$("#productIDSuggestions").hasClass("hidden")) {
+            var highlightedProductIDSuggestion = null;
+            if ($("#productIDSuggestions").find('ul').length > 0) {
+                highlightedProductIDSuggestion = $("#productIDSuggestions").find('.my-menu-item-hover');
+                if (!highlightedProductIDSuggestion || curSelectedProductIDSuggestion == -1)
+                    searchVulnsAction();
+                else
+                    document.getElementById('product-id-suggestion-' + curSelectedProductIDSuggestion).click();
+            }
+        }
+    }
+});
 
 // check for API key
 if (localStorage.getItem('apiKey') !== null)
@@ -1587,8 +1697,30 @@ if (localStorage.getItem('apiKey') !== null)
 // fix dropdown open buttons to close again on click
 fixDropdownClicking();
 
-// setup configuration from LocalStorage
-setupConfigFromLocalstorage();
+// set up configuration from LocalStorage
+setUpConfigFromLocalstorage();
+
+
+// Init and set up vuln ID types selection
+var isVulnIDTypesSelectionOpen = false;
+document.getElementById('vuln-ids-config-ms-trigger').addEventListener('click', () => isVulnIDTypesSelectionOpen ? closeVulnIDTypesSelection() : openVulnIDTypesSelection());
+
+document.addEventListener('pointerdown', e => {
+    // Close multi-select on outside click, but not when clicking inside the dropdown
+    const wrap = document.getElementById('vuln-ids-config-ms-wrap');
+    if (!wrap.contains(e.target)) closeVulnIDTypesSelection();
+});
+
+document.getElementById('vuln-ids-config-ms-all').addEventListener('click', () => {
+    vulnIDTypesSelectionAllNone(true);
+});
+
+document.getElementById('vuln-ids-config-ms-none').addEventListener('click', () => {
+    vulnIDTypesSelectionAllNone(false);
+});
+
+renderVulnIDTypesSelectionOptions();
+
 
 // check for existing query in URL and insert its parameters
 initQuery();

--- a/src/search_vulns/web_server_files/templates/index.html
+++ b/src/search_vulns/web_server_files/templates/index.html
@@ -7,7 +7,7 @@
             <div class="dropdown dropdown-open sm:mr-2 md:mr-3 w-full" id="queryInputConstruct"
                 onfocusout="closeProductIDSuggestions(event)">
                 <label class="input flex w-full items-center gap-5 sm:mr-1 md:mr-2">
-                    <i class="fa-solid fa-database"></i>
+                    <i class="fa-solid fa-magnifying-glass"></i>
                     <input type="text" class="w-full text-base" autofocus
                         placeholder="Enter Product or Vulnerability IDs" name="query" id="query" />
                     <kbd class="kbd kbd-base text-xl">⏎</kbd>

--- a/src/search_vulns/web_server_files/templates/index.html
+++ b/src/search_vulns/web_server_files/templates/index.html
@@ -96,6 +96,35 @@
                             </div>
                         </label>
                     </div>
+                    <div class="form-control mt-3">
+                        <div class="flex items-center min-w-0 text-sm w-full">
+                            <div class="flex items-center mr-2 shrink-0 label-text text-base-content text-sm">
+                                Vuln IDs <div class="tooltip tooltip-bottom ml-1">
+                                    <div class="tooltip-content">Choose types of vulnerability IDs to be shown, e.g.
+                                        CVE, GHSA etc.</div>
+                                    <i class="fas fa-info-circle text-content"></i>
+                                </div>
+                            </div>
+                            <div class="relative w-full ml-1" id="vuln-ids-config-ms-wrap">
+                                <div tabindex="0" id="vuln-ids-config-ms-trigger" class="w-full h-10 px-3 flex items-center gap-2 cursor-pointer
+                                            bg-base-100 border border-base-300 rounded-lg text-sm">
+                                    <span id="vuln-ids-config-ms-ph" class="flex-1 text-base-content/40">Pick ID Types
+                                        ...</span>
+                                    <span id="vuln-ids-config-ms-arrow"><i class="fa-solid fa-caret-down"></i></span>
+                                </div>
+                                <div id="vuln-ids-config-ms-dropdown" class="hidden absolute top-[calc(100%+4px)] left-0 right-0
+                                    bg-base-100 border border-base-300 rounded-box shadow-md overflow-hidden">
+                                    <ul id="vuln-ids-config-ms-opts" class="max-h-52 overflow-y-auto"></ul>
+                                    <div class="flex justify-between px-4 py-1.5 border-t border-base-200 text-xs">
+                                        <button type="button" id="vuln-ids-config-ms-all"
+                                            class="link link-primary">All</button>
+                                        <button type="button" id="vuln-ids-config-ms-none"
+                                            class="link link-primary">None</button>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
             <div class="dropdown dropdown-center mr-1">

--- a/tests/run_all_tests.sh
+++ b/tests/run_all_tests.sh
@@ -61,5 +61,9 @@ echo '[+] Running test_redhat_backpatches.py'
 python3 "${SCRIPT_DIR}/test_redhat_backpatches.py"
 EXIT_12=$?
 
+echo '[+] Running test_cli_backend.py'
+python3 "${SCRIPT_DIR}/test_cli_backend.py"
+EXIT_13=$?
+
 # https://stackoverflow.com/a/16358989
-! (( $EXIT_1 || $EXIT_2 || $EXIT_3 || $EXIT_4 || $EXIT_7 || $EXIT_8 || $EXIT_9 || $EXIT_10 || $EXIT_11 || $EXIT_12 ))
+! (( $EXIT_1 || $EXIT_2 || $EXIT_3 || $EXIT_4 || $EXIT_7 || $EXIT_8 || $EXIT_9 || $EXIT_10 || $EXIT_11 || $EXIT_12  || $EXIT_13 ))

--- a/tests/run_all_tests.sh
+++ b/tests/run_all_tests.sh
@@ -65,5 +65,9 @@ echo '[+] Running test_cli_backend.py'
 python3 "${SCRIPT_DIR}/test_cli_backend.py"
 EXIT_13=$?
 
+echo '[+] Running test_cli_integration.py'
+python3 "${SCRIPT_DIR}/test_cli_integration.py"
+EXIT_14=$?
+
 # https://stackoverflow.com/a/16358989
-! (( $EXIT_1 || $EXIT_2 || $EXIT_3 || $EXIT_4 || $EXIT_7 || $EXIT_8 || $EXIT_9 || $EXIT_10 || $EXIT_11 || $EXIT_12  || $EXIT_13 ))
+! (( $EXIT_1 || $EXIT_2 || $EXIT_3 || $EXIT_4 || $EXIT_7 || $EXIT_8 || $EXIT_9 || $EXIT_10 || $EXIT_11 || $EXIT_12  || $EXIT_13 || $EXIT_14 ))

--- a/tests/test_cli_backend.py
+++ b/tests/test_cli_backend.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import os
+import unittest
+from io import BytesIO
+from unittest.mock import MagicMock, patch
+
+from search_vulns.cli_backend import (
+    DEFAULT_API_URL,
+    ApiBackend,
+    ApiError,
+    LocalBackend,
+    _parse_api_result,
+    select_backend,
+)
+from search_vulns.models.SearchVulnsResult import SearchVulnsResult
+
+
+# ------------------------------------------------ fixtures
+def _fake_api_json(
+    cpes=None, pot_cpes=None, vulns=None, version_status=None
+):
+    return json.dumps({
+        "product_ids": {"cpe": cpes or [], "purl": [], "raw": []},
+        "pot_product_ids": {"cpe": pot_cpes or [], "purl": [], "raw": []},
+        "vulns": vulns or {},
+        "version_status": version_status or {},
+    }).encode()
+
+
+def _mock_urlopen(response_bytes, status=200):
+    resp = MagicMock()
+    resp.read.return_value = response_bytes
+    resp.__enter__ = MagicMock(return_value=resp)
+    resp.__exit__ = MagicMock(return_value=False)
+    return resp
+
+
+# ------------------------------------------------ backend selection
+class TestBackendSelection(unittest.TestCase):
+    def _args(self, **kw):
+        defaults = {"api_key": None, "api_url": None, "cpe_search_threshold": None}
+        defaults.update(kw)
+        return argparse.Namespace(**defaults)
+
+    def test_no_api_flags_selects_local(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("SV_API_KEY", None)
+            backend = select_backend(self._args(), {})
+        self.assertIsInstance(backend, LocalBackend)
+
+    def test_api_key_flag_selects_api(self):
+        backend = select_backend(self._args(api_key="test-key"), {})
+        self.assertIsInstance(backend, ApiBackend)
+
+    def test_env_var_selects_api(self):
+        with patch.dict(os.environ, {"SV_API_KEY": "env-key"}):
+            backend = select_backend(self._args(), {})
+        self.assertIsInstance(backend, ApiBackend)
+
+    def test_custom_url_selects_api(self):
+        backend = select_backend(
+            self._args(api_key="k", api_url="https://custom.example.com/api/"), {}
+        )
+        self.assertIsInstance(backend, ApiBackend)
+
+    def test_api_key_precedence_over_env(self):
+        with patch.dict(os.environ, {"SV_API_KEY": "env-key"}):
+            backend = select_backend(self._args(api_key="flag-key"), {})
+        self.assertIsInstance(backend, ApiBackend)
+        self.assertEqual(backend._api_key, "flag-key")
+
+
+# ------------------------------------------------ API backend (mocked HTTP)
+class TestApiBackend(unittest.TestCase):
+    def _backend(self, api_url=None):
+        return ApiBackend("test-key", api_url or DEFAULT_API_URL)
+
+    @patch("search_vulns.cli_backend.urlopen")
+    def test_suggest_calls_correct_endpoint(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_urlopen(_fake_api_json())
+        self._backend().suggest("Apache 2.4")
+        call_args = mock_urlopen.call_args
+        req = call_args[0][0]
+        self.assertIn("/product-id-suggestions", req.full_url)
+        self.assertIn("query=Apache", req.full_url)
+
+    @patch("search_vulns.cli_backend.urlopen")
+    def test_suggest_sends_api_key_header(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_urlopen(_fake_api_json())
+        self._backend().suggest("test")
+        req = mock_urlopen.call_args[0][0]
+        self.assertEqual(req.get_header("Api-key"), "test-key")
+
+    @patch("search_vulns.cli_backend.urlopen")
+    def test_suggest_parses_response(self, mock_urlopen):
+        pot = [["cpe:2.3:a:apache:tomcat:9.0.22:*:*:*:*:*:*:*", 0.95]]
+        mock_urlopen.return_value = _mock_urlopen(_fake_api_json(pot_cpes=pot))
+        result = self._backend().suggest("Apache Tomcat 9")
+        self.assertIsInstance(result, SearchVulnsResult)
+        self.assertEqual(len(result.pot_product_ids.cpe), 1)
+
+    @patch("search_vulns.cli_backend.urlopen")
+    def test_search_calls_correct_endpoint(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_urlopen(_fake_api_json())
+        self._backend().search("cpe:2.3:a:apache:tomcat:9.0.22:*:*:*:*:*:*:*")
+        req = mock_urlopen.call_args[0][0]
+        self.assertIn("/search-vulns", req.full_url)
+
+    @patch("search_vulns.cli_backend.urlopen")
+    def test_search_passes_flags(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_urlopen(_fake_api_json())
+        self._backend().search("test", ignore_general_product_vulns=True)
+        req = mock_urlopen.call_args[0][0]
+        self.assertIn("ignore-general-product-vulns=true", req.full_url)
+
+    @patch("search_vulns.cli_backend.urlopen")
+    def test_http_error_non_fatal(self, mock_urlopen):
+        from urllib.error import HTTPError
+        mock_urlopen.side_effect = HTTPError(
+            "http://x", 500, "fail", {}, BytesIO(b'{"message":"err"}')
+        )
+        with self.assertRaises(ApiError):
+            self._backend()._api_get("/test", {}, fatal=False)
+
+    @patch("search_vulns.cli_backend.urlopen")
+    def test_http_error_fatal(self, mock_urlopen):
+        from urllib.error import HTTPError
+        mock_urlopen.side_effect = HTTPError(
+            "http://x", 500, "fail", {}, BytesIO(b'{"message":"err"}')
+        )
+        with self.assertRaises(SystemExit):
+            self._backend()._api_get("/test", {}, fatal=True)
+
+    @patch("search_vulns.cli_backend.urlopen")
+    def test_custom_api_url(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_urlopen(_fake_api_json())
+        self._backend(api_url="https://custom.example.com/api/").suggest("test")
+        req = mock_urlopen.call_args[0][0]
+        self.assertTrue(req.full_url.startswith("https://custom.example.com/api/"))
+
+
+# ------------------------------------------------ API response parsing
+class TestParseApiResult(unittest.TestCase):
+    def test_parses_product_ids(self):
+        data = json.loads(_fake_api_json(cpes=["cpe:2.3:a:v:p:1:*:*:*:*:*:*:*"]))
+        result = _parse_api_result(data)
+        self.assertEqual(result.product_ids.cpe, ["cpe:2.3:a:v:p:1:*:*:*:*:*:*:*"])
+
+    def test_parses_pot_product_ids(self):
+        pot = [["cpe:2.3:a:v:p:1:*:*:*:*:*:*:*", 0.85]]
+        data = json.loads(_fake_api_json(pot_cpes=pot))
+        result = _parse_api_result(data)
+        self.assertEqual(len(result.pot_product_ids.cpe), 1)
+        self.assertAlmostEqual(result.pot_product_ids.cpe[0][1], 0.85)
+
+    def test_parses_vulns(self):
+        vulns = {
+            "CVE-2024-0001": {
+                "match_reason": "version_in_range",
+                "tracked_by": {"nvd": "https://nvd.nist.gov/vuln/detail/CVE-2024-0001"},
+                "matched_by": {"nvd": {"match_reason": "version_in_range", "confidence": 1.0}},
+                "description": "Test vuln",
+                "severity": {
+                    "CVSS": {"type": "CVSS", "score": "7.5", "version": "3.1", "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"},
+                },
+                "cisa_kev": False,
+                "exploits": [],
+                "cwe_ids": ["CWE-79"],
+                "aliases": {"CVE-2024-0001": "https://nvd.nist.gov/vuln/detail/CVE-2024-0001"},
+            }
+        }
+        data = json.loads(_fake_api_json(vulns=vulns))
+        result = _parse_api_result(data)
+        self.assertIn("CVE-2024-0001", result.vulns)
+        v = result.vulns["CVE-2024-0001"]
+        self.assertEqual(float(v.get_cvss_score()), 7.5)
+        self.assertIn("CWE-79", v.cwe_ids)
+
+    def test_parses_version_status(self):
+        vs = {"status": "OUTDATED", "latest": "9.0.98", "reference": "https://example.com"}
+        data = json.loads(_fake_api_json(version_status=vs))
+        result = _parse_api_result(data)
+        self.assertEqual(result.version_status.status.value, "OUTDATED")
+        self.assertEqual(result.version_status.latest, "9.0.98")
+
+    def test_empty_response(self):
+        data = json.loads(_fake_api_json())
+        result = _parse_api_result(data)
+        self.assertIsInstance(result, SearchVulnsResult)
+        self.assertEqual(len(result.vulns), 0)
+        self.assertEqual(len(result.product_ids.cpe), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cli_formatters.py
+++ b/tests/test_cli_formatters.py
@@ -1,0 +1,383 @@
+#!/usr/bin/env python3
+
+import json
+import unittest
+from datetime import datetime
+
+from search_vulns.cli_formatters import (
+    ALLOWED_MD_COLS,
+    format_ansi,
+    format_json_batch,
+    format_md,
+    parse_md_cols,
+    print_vulns,
+    score_bar,
+    sort_and_cap_vulns,
+    strip_ansi,
+)
+from search_vulns.models.SearchVulnsResult import (
+    PotProductIDsResult,
+    ProductIDsResult,
+    SearchVulnsResult,
+    VersionStatus,
+    VersionStatusResult,
+)
+from search_vulns.models.Severity import SeverityCVSS, SeverityEPSS, SeverityType
+from search_vulns.models.Vulnerability import (
+    DataSource,
+    Match,
+    MatchReason,
+    Vulnerability,
+)
+
+
+# ------------------------------------------------ fixture helper
+def _make_vuln(
+    vid="CVE-2024-0001",
+    cvss=7.5,
+    cvss_ver="3.1",
+    epss=0.5,
+    desc="Test vulnerability",
+    cisa_kev=False,
+    exploits=None,
+    cwe_ids=None,
+    published=None,
+):
+    severity = {}
+    if cvss >= 0:
+        severity[SeverityType.CVSS] = SeverityCVSS(
+            score=str(cvss), version=str(cvss_ver), vector="CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
+        )
+    if epss > 0:
+        severity[SeverityType.EPSS] = SeverityEPSS(score=str(epss))
+
+    return Vulnerability(
+        id=vid,
+        match_reason=MatchReason.VERSION_IN_RANGE,
+        tracked_by={DataSource.NVD: f"https://nvd.nist.gov/vuln/detail/{vid}"},
+        matched_by={DataSource.NVD: Match(match_reason=MatchReason.VERSION_IN_RANGE, confidence=1.0)},
+        description=desc,
+        severity=severity,
+        cisa_kev=cisa_kev,
+        exploits=set(exploits or []),
+        cwe_ids=set(cwe_ids or []),
+        aliases={vid: f"https://nvd.nist.gov/vuln/detail/{vid}"},
+        published=published or datetime(2024, 1, 15, 0, 0, 0),
+    )
+
+
+def _make_result(vulns=None, cpes=None, version_status=None, pot_cpes=None):
+    return SearchVulnsResult(
+        product_ids=ProductIDsResult(cpe=cpes or []),
+        pot_product_ids=PotProductIDsResult(cpe=pot_cpes or []),
+        vulns={v.id: v for v in (vulns or [])},
+        version_status=version_status or VersionStatusResult(),
+    )
+
+
+# ------------------------------------------------ sort_and_cap_vulns
+class TestSortAndCap(unittest.TestCase):
+    def _vulns_dict(self, specs):
+        return {v.id: v for v in [_make_vuln(vid=s[0], cvss=s[1], epss=s[2]) for s in specs]}
+
+    def test_sort_by_cvss_desc(self):
+        vulns = self._vulns_dict([
+            ("CVE-A", 9.8, 0.1),
+            ("CVE-B", 4.0, 0.1),
+            ("CVE-C", 7.5, 0.1),
+            ("CVE-D", 0.0, 0.0),
+            ("CVE-E", 6.1, 0.1),
+        ])
+        result = sort_and_cap_vulns(vulns, None)
+        ids = list(result.keys())
+        self.assertEqual(ids, ["CVE-A", "CVE-C", "CVE-E", "CVE-B", "CVE-D"])
+
+    def test_sort_secondary_epss(self):
+        vulns = self._vulns_dict([("CVE-A", 7.5, 0.3), ("CVE-B", 7.5, 0.9)])
+        result = sort_and_cap_vulns(vulns, None)
+        ids = list(result.keys())
+        self.assertEqual(ids[0], "CVE-B")
+
+    def test_sort_tertiary_id(self):
+        vulns = self._vulns_dict([("CVE-B", 7.5, 0.5), ("CVE-A", 7.5, 0.5)])
+        result = sort_and_cap_vulns(vulns, None)
+        ids = list(result.keys())
+        self.assertEqual(ids, ["CVE-A", "CVE-B"])
+
+    def test_cap_truncates(self):
+        vulns = self._vulns_dict([(f"CVE-{i}", float(i), 0.1) for i in range(10)])
+        result = sort_and_cap_vulns(vulns, 3)
+        self.assertEqual(len(result), 3)
+
+    def test_cap_none_returns_all(self):
+        vulns = self._vulns_dict([(f"CVE-{i}", float(i), 0.1) for i in range(5)])
+        result = sort_and_cap_vulns(vulns, None)
+        self.assertEqual(len(result), 5)
+
+    def test_cap_zero_returns_empty(self):
+        vulns = self._vulns_dict([("CVE-A", 7.5, 0.5)])
+        result = sort_and_cap_vulns(vulns, 0)
+        self.assertEqual(len(result), 0)
+
+    def test_empty_vulns(self):
+        result = sort_and_cap_vulns({}, None)
+        self.assertEqual(result, {})
+
+
+# ------------------------------------------------ format_md
+class TestFormatMd(unittest.TestCase):
+    def test_default_cols(self):
+        result = _make_result([_make_vuln()])
+        out = format_md(result, list(ALLOWED_MD_COLS[:3]))
+        lines = out.strip().split("\n")
+        header_line = [l for l in lines if l.startswith("| Vuln")][0]
+        self.assertIn("Vuln ID", header_line)
+        self.assertIn("CVSS", header_line)
+        self.assertIn("Description", header_line)
+
+    def test_all_cols(self):
+        result = _make_result([_make_vuln(cwe_ids=["CWE-79"], exploits=["https://exploit.example"])])
+        out = format_md(result, list(ALLOWED_MD_COLS))
+        header_line = [l for l in out.split("\n") if l.startswith("| Vuln")][0]
+        for col_name in ("Vuln ID", "CVSS", "Description", "EPSS", "CWE", "Exploits"):
+            self.assertIn(col_name, header_line)
+
+    def test_frontmatter_from_cpe(self):
+        result = _make_result(
+            [_make_vuln()],
+            cpes=["cpe:2.3:a:apache:tomcat:9.0.22:*:*:*:*:*:*:*"],
+        )
+        out = format_md(result, ["id"])
+        self.assertIn('cpe: "cpe:2.3:a:apache:tomcat:9.0.22', out)
+        self.assertIn('product: "Tomcat"', out)
+        self.assertIn('version: "9.0.22"', out)
+
+    def test_frontmatter_no_cpe(self):
+        result = _make_result([_make_vuln()])
+        out = format_md(result, ["id"])
+        self.assertIn("---", out)
+        self.assertIn('cpe: ""', out)
+
+    def test_pipe_escaping(self):
+        result = _make_result([_make_vuln(desc="a | b")])
+        out = format_md(result, ["description"])
+        data_lines = [l for l in out.split("\n") if l.startswith("|") and "Description" not in l and ":---" not in l]
+        self.assertTrue(any("a \\| b" in l for l in data_lines))
+
+    def test_newline_escaping(self):
+        result = _make_result([_make_vuln(desc="line1\nline2")])
+        out = format_md(result, ["description"])
+        data_lines = [l for l in out.split("\n") if l.startswith("|") and "Description" not in l and ":---" not in l]
+        self.assertTrue(any("line1 line2" in l for l in data_lines))
+
+    def test_cvss_cell(self):
+        result = _make_result([_make_vuln(cvss=8.8, cvss_ver="3.1")])
+        out = format_md(result, ["cvss"])
+        self.assertIn("8.8 (v3.1)", out)
+
+    def test_cvss_cell_missing(self):
+        v = _make_vuln(cvss=-1)
+        v.severity = {}
+        result = _make_result([v])
+        out = format_md(result, ["cvss"])
+        data_lines = [l for l in out.split("\n") if l.startswith("|") and "CVSS" not in l and ":---" not in l]
+        self.assertTrue(any("| - |" in l for l in data_lines))
+
+    def test_epss_cell(self):
+        result = _make_result([_make_vuln(epss=0.84)])
+        out = format_md(result, ["epss"])
+        self.assertIn("0.84", out)
+
+    def test_epss_cell_zero(self):
+        result = _make_result([_make_vuln(epss=0)])
+        out = format_md(result, ["epss"])
+        data_lines = [l for l in out.split("\n") if l.startswith("|") and "EPSS" not in l and ":---" not in l]
+        self.assertTrue(any("| - |" in l for l in data_lines))
+
+    def test_cwe_cell(self):
+        result = _make_result([_make_vuln(cwe_ids=["CWE-89", "CWE-79"])])
+        out = format_md(result, ["cwe"])
+        self.assertIn("CWE-79, CWE-89", out)
+
+    def test_exploits_cell(self):
+        result = _make_result([_make_vuln(exploits=["http://a", "http://b", "http://c"])])
+        out = format_md(result, ["exploits"])
+        self.assertIn("3", out)
+
+    def test_id_cell_with_link(self):
+        result = _make_result([_make_vuln(vid="CVE-2024-1234")])
+        out = format_md(result, ["id"])
+        self.assertIn("[CVE-2024-1234](https://nvd.nist.gov/vuln/detail/CVE-2024-1234)", out)
+
+    def test_empty_vulns_produces_header_only(self):
+        result = _make_result([])
+        out = format_md(result, ["id", "cvss", "description"])
+        lines = [l for l in out.strip().split("\n") if l.startswith("|")]
+        self.assertEqual(len(lines), 2)  # header + alignment
+
+    def test_multiple_queries_separated(self):
+        r1 = _make_result([_make_vuln(vid="CVE-A")], cpes=["cpe:2.3:a:v:p:1:*:*:*:*:*:*:*"])
+        r2 = _make_result([_make_vuln(vid="CVE-B")], cpes=["cpe:2.3:a:v:q:2:*:*:*:*:*:*:*"])
+        out1 = format_md(r1, ["id"])
+        out2 = format_md(r2, ["id"])
+        combined = out1 + "\n\n" + out2
+        self.assertIn('cpe: "cpe:2.3:a:v:p:1', combined)
+        self.assertIn('cpe: "cpe:2.3:a:v:q:2', combined)
+        self.assertEqual(combined.count('cpe: "cpe:2.3:'), 2)
+
+
+# ------------------------------------------------ parse_md_cols
+class TestParseMdCols(unittest.TestCase):
+    def test_valid_subset(self):
+        self.assertEqual(parse_md_cols("id,epss"), ["id", "epss"])
+
+    def test_default_string(self):
+        self.assertEqual(parse_md_cols("id,cvss,description"), ["id", "cvss", "description"])
+
+    def test_invalid_col_rejected(self):
+        with self.assertRaises(ValueError):
+            parse_md_cols("id,foobar")
+
+    def test_whitespace_tolerant(self):
+        self.assertEqual(parse_md_cols(" id , cvss "), ["id", "cvss"])
+
+    def test_duplicate_deduped(self):
+        self.assertEqual(parse_md_cols("id,id,cvss"), ["id", "cvss"])
+
+
+# ------------------------------------------------ format_ansi
+class TestFormatAnsi(unittest.TestCase):
+    def test_severity_grouping(self):
+        vulns = [
+            _make_vuln(vid="CVE-CRIT", cvss=9.5),
+            _make_vuln(vid="CVE-MED", cvss=5.0),
+            _make_vuln(vid="CVE-LOW", cvss=2.0),
+        ]
+        out = format_ansi("test", _make_result(vulns))
+        plain = strip_ansi(out)
+        self.assertIn("CRITICAL", plain)
+        self.assertIn("MEDIUM", plain)
+        self.assertIn("LOW", plain)
+
+    def test_kev_badge(self):
+        out = format_ansi("test", _make_result([_make_vuln(cisa_kev=True)]))
+        plain = strip_ansi(out)
+        self.assertIn("KEV", plain)
+
+    def test_exploit_badge(self):
+        out = format_ansi("test", _make_result([_make_vuln(exploits=["http://a", "http://b"])]))
+        plain = strip_ansi(out)
+        self.assertIn("EXP x2", plain)
+
+    def test_version_status_banner(self):
+        vs = VersionStatusResult(status=VersionStatus.OUTDATED, latest="9.0.98")
+        out = format_ansi("test", _make_result([], version_status=vs))
+        plain = strip_ansi(out)
+        self.assertIn("OUTDATED", plain)
+        self.assertIn("9.0.98", plain)
+
+    def test_no_vulns_message(self):
+        out = format_ansi("test", _make_result([]))
+        plain = strip_ansi(out)
+        self.assertIn("No vulnerabilities found", plain)
+
+    def test_color_false_strips_ansi(self):
+        out = format_ansi("test", _make_result([_make_vuln()]), color=False)
+        self.assertNotIn("\033[", out)
+
+    def test_description_truncation(self):
+        long_desc = "A" * 200
+        out = format_ansi("test", _make_result([_make_vuln(desc=long_desc)]))
+        plain = strip_ansi(out)
+        self.assertIn("...", plain)
+        self.assertNotIn("A" * 200, plain)
+
+
+# ------------------------------------------------ format_json_batch
+class TestFormatJsonBatch(unittest.TestCase):
+    def test_valid_json(self):
+        results = {"q1": _make_result([_make_vuln()])}
+        out = format_json_batch(results)
+        parsed = json.loads(out)
+        self.assertIsInstance(parsed, dict)
+
+    def test_keys_are_queries(self):
+        results = {"query_a": _make_result(), "query_b": _make_result()}
+        out = format_json_batch(results)
+        parsed = json.loads(out)
+        self.assertIn("query_a", parsed)
+        self.assertIn("query_b", parsed)
+
+    def test_result_structure(self):
+        results = {"q": _make_result([_make_vuln()])}
+        out = format_json_batch(results)
+        parsed = json.loads(out)
+        self.assertIn("product_ids", parsed["q"])
+        self.assertIn("vulns", parsed["q"])
+
+    def test_warning_for_bad_result(self):
+        results = {"q": "Warning: Could not find matching software for query"}
+        out = format_json_batch(results)
+        parsed = json.loads(out)
+        self.assertIsInstance(parsed["q"], str)
+
+
+# ------------------------------------------------ print_vulns
+class TestPrintVulns(unittest.TestCase):
+    def test_to_string_returns_text(self):
+        vulns = {v.id: v for v in [_make_vuln(vid="CVE-2024-1111")]}
+        out = print_vulns(vulns, to_string=True)
+        self.assertIsNotNone(out)
+        self.assertIn("CVE-2024-1111", out)  # type: ignore[arg-type]
+
+    def test_to_string_no_ansi(self):
+        vulns = {v.id: v for v in [_make_vuln()]}
+        out = print_vulns(vulns, to_string=True)
+        self.assertIsNotNone(out)
+        self.assertNotIn("\033[", out)  # type: ignore[arg-type]
+
+    def test_exploit_display(self):
+        vulns = {v.id: v for v in [_make_vuln(exploits=["http://exploit1", "http://exploit2"])]}
+        out = print_vulns(vulns, to_string=True)
+        self.assertIsNotNone(out)
+        self.assertIn("http://exploit1", out)  # type: ignore[arg-type]
+        self.assertIn("http://exploit2", out)  # type: ignore[arg-type]
+
+    def test_published_date(self):
+        vulns = {v.id: v for v in [_make_vuln(published=datetime(2024, 3, 15))]}
+        out = print_vulns(vulns, to_string=True)
+        self.assertIsNotNone(out)
+        self.assertIn("2024-03-15", out)  # type: ignore[arg-type]
+
+    def test_kev_label(self):
+        vulns = {v.id: v for v in [_make_vuln(cisa_kev=True)]}
+        out = print_vulns(vulns, to_string=True)
+        self.assertIsNotNone(out)
+        self.assertIn("Actively exploited", out)  # type: ignore[arg-type]
+
+
+# ------------------------------------------------ score_bar
+class TestScoreBar(unittest.TestCase):
+    def test_full_score(self):
+        bar = strip_ansi(score_bar(1.0, width=12))
+        self.assertEqual(bar.count("█"), 12)
+        self.assertEqual(bar.count("░"), 0)
+
+    def test_zero_score(self):
+        bar = strip_ansi(score_bar(0.0, width=12))
+        self.assertEqual(bar.count("█"), 0)
+        self.assertEqual(bar.count("░"), 12)
+
+    def test_mid_score(self):
+        bar = strip_ansi(score_bar(0.5, width=12))
+        self.assertGreater(bar.count("█"), 0)
+        self.assertGreater(bar.count("░"), 0)
+
+    def test_negative_score_uses_abs(self):
+        bar_pos = strip_ansi(score_bar(0.8, width=12))
+        bar_neg = strip_ansi(score_bar(-0.8, width=12))
+        self.assertEqual(bar_pos.count("█"), bar_neg.count("█"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+
+import json
+import os
+import tempfile
+import unittest
+from datetime import datetime
+from io import StringIO
+from unittest.mock import MagicMock, patch
+
+from search_vulns.cli import _read_query_file, main, parse_args
+from search_vulns.models.SearchVulnsResult import (
+    PotProductIDsResult,
+    ProductIDsResult,
+    SearchVulnsResult,
+    VersionStatusResult,
+)
+from search_vulns.models.Severity import SeverityCVSS, SeverityType
+from search_vulns.models.Vulnerability import (
+    DataSource,
+    Match,
+    MatchReason,
+    Vulnerability,
+)
+
+
+# ------------------------------------------------ fixtures
+_DUMMY_CONFIG = {"DATABASE_CONNECTION": "none"}
+
+
+def _make_vuln(vid="CVE-FAKE", cvss_score="7.5"):
+    return Vulnerability(
+        id=vid,
+        match_reason=MatchReason.VERSION_IN_RANGE,
+        tracked_by={DataSource.NVD: f"https://nvd.nist.gov/vuln/detail/{vid}"},
+        matched_by={DataSource.NVD: Match(match_reason=MatchReason.VERSION_IN_RANGE, confidence=1.0)},
+        description="Test vulnerability",
+        severity={SeverityType.CVSS: SeverityCVSS(score=cvss_score, version="3.1", vector="CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N")},
+        aliases={vid: f"https://nvd.nist.gov/vuln/detail/{vid}"},
+        published=datetime(2024, 1, 1),
+    )
+
+
+def _make_search_result(n_vulns=3):
+    vulns = {}
+    for i in range(n_vulns):
+        vid = f"CVE-2024-{i:04d}"
+        score = str(round(max(0.1, 10.0 - i * 0.5), 1))
+        vulns[vid] = _make_vuln(vid, score)
+    return SearchVulnsResult(
+        product_ids=ProductIDsResult(cpe=["cpe:2.3:a:vendor:product:1.0:*:*:*:*:*:*:*"]),
+        pot_product_ids=PotProductIDsResult(),
+        vulns=vulns,
+        version_status=VersionStatusResult(),
+    )
+
+
+def _mock_backend(search_result=None, is_good=True):
+    backend = MagicMock()
+    if search_result is None:
+        search_result = _make_search_result()
+    backend.search.return_value = (is_good, search_result)
+    return backend
+
+
+def _run_main(argv, backend=None):
+    if backend is None:
+        backend = _mock_backend()
+    captured = StringIO()
+    with patch("sys.argv", ["search_vulns"] + argv), \
+         patch("search_vulns.cli._load_config", return_value=_DUMMY_CONFIG), \
+         patch("search_vulns.cli.select_backend", return_value=backend), \
+         patch("sys.stdout", captured):
+        main()
+    return captured.getvalue()
+
+
+# ------------------------------------------------ arg parsing
+class TestArgParsing(unittest.TestCase):
+    def _parse(self, argv):
+        with patch("sys.argv", ["search_vulns"] + argv):
+            return parse_args()
+
+    def test_api_key_parsed(self):
+        args = self._parse(["--api-key", "abc", "-q", "test"])
+        self.assertEqual(args.api_key, "abc")
+
+    def test_api_url_parsed(self):
+        args = self._parse(["--api-url", "https://x.com/api/", "--api-key", "k", "-q", "test"])
+        self.assertEqual(args.api_url, "https://x.com/api/")
+
+    def test_api_url_default_none(self):
+        args = self._parse(["-q", "test"])
+        self.assertIsNone(args.api_url)
+
+    def test_query_file_parsed(self):
+        args = self._parse(["--query-file", "f.txt"])
+        self.assertEqual(args.query_file, "f.txt")
+
+    def test_interactive_flag(self):
+        args = self._parse(["-i"])
+        self.assertTrue(args.interactive)
+
+    def test_vuln_count_parsed(self):
+        args = self._parse(["--vuln-count", "5", "-q", "test"])
+        self.assertEqual(args.vuln_count, 5)
+
+    def test_md_cols_parsed(self):
+        args = self._parse(["--md-cols", "id,epss,cwe", "-q", "test"])
+        self.assertEqual(args.md_cols, "id,epss,cwe")
+
+    def test_format_ansi(self):
+        args = self._parse(["-f", "ansi", "-q", "test"])
+        self.assertEqual(args.format, "ansi")
+
+    def test_format_md(self):
+        args = self._parse(["-f", "md", "-q", "test"])
+        self.assertEqual(args.format, "md")
+
+    def test_format_rejects_invalid(self):
+        with self.assertRaises(SystemExit):
+            self._parse(["-f", "invalid", "-q", "test"])
+
+    def test_existing_flags_unchanged(self):
+        self.assertTrue(self._parse(["-u"]).update)
+        self.assertTrue(self._parse(["--full-update"]).full_update)
+        self.assertTrue(self._parse(["-V"]).version)
+
+
+# ------------------------------------------------ query file reading
+class TestQueryFileReading(unittest.TestCase):
+    def _write_tmp(self, content):
+        f = tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False)
+        f.write(content)
+        f.close()
+        return f.name
+
+    def test_reads_lines(self):
+        path = self._write_tmp("query1\nquery2\nquery3\n")
+        try:
+            self.assertEqual(_read_query_file(path), ["query1", "query2", "query3"])
+        finally:
+            os.unlink(path)
+
+    def test_skips_blank_lines(self):
+        path = self._write_tmp("query1\n\nquery2\n\n\n")
+        try:
+            self.assertEqual(_read_query_file(path), ["query1", "query2"])
+        finally:
+            os.unlink(path)
+
+    def test_skips_comments(self):
+        path = self._write_tmp("# comment\nquery1\n# another\nquery2\n")
+        try:
+            self.assertEqual(_read_query_file(path), ["query1", "query2"])
+        finally:
+            os.unlink(path)
+
+    def test_strips_whitespace(self):
+        path = self._write_tmp("  query1  \n  query2\n")
+        try:
+            self.assertEqual(_read_query_file(path), ["query1", "query2"])
+        finally:
+            os.unlink(path)
+
+    def test_missing_file_exits(self):
+        with self.assertRaises(SystemExit):
+            _read_query_file("/nonexistent/path/file.txt")
+
+    def test_empty_file(self):
+        path = self._write_tmp("# only comments\n\n")
+        try:
+            self.assertEqual(_read_query_file(path), [])
+        finally:
+            os.unlink(path)
+
+    def test_combined_with_cli_queries(self):
+        path = self._write_tmp("C\nD\n")
+        try:
+            with patch("sys.argv", ["search_vulns", "-q", "A", "-q", "B", "--query-file", path]):
+                args = parse_args()
+            queries = list(args.queries or [])
+            queries.extend(_read_query_file(path))
+            self.assertEqual(queries, ["A", "B", "C", "D"])
+        finally:
+            os.unlink(path)
+
+
+# ------------------------------------------------ vuln count integration
+class TestVulnCountIntegration(unittest.TestCase):
+    def test_vuln_count_caps_output(self):
+        backend = _mock_backend(search_result=_make_search_result(20))
+        output = _run_main(["-f", "json", "--vuln-count", "5", "-q", "test"], backend)
+        data = json.loads(output)
+        self.assertEqual(len(data["test"]["vulns"]), 5)
+
+    def test_vuln_count_preserves_top(self):
+        backend = _mock_backend(search_result=_make_search_result(10))
+        output = _run_main(["-f", "json", "--vuln-count", "3", "-q", "test"], backend)
+        data = json.loads(output)
+        vuln_ids = list(data["test"]["vulns"].keys())
+        self.assertIn("CVE-2024-0000", vuln_ids)
+
+    def test_no_vuln_count_passes_all(self):
+        backend = _mock_backend(search_result=_make_search_result(10))
+        output = _run_main(["-f", "json", "-q", "test"], backend)
+        data = json.loads(output)
+        self.assertEqual(len(data["test"]["vulns"]), 10)
+
+
+# ------------------------------------------------ output routing
+class TestOutputRouting(unittest.TestCase):
+    def test_txt_to_stdout(self):
+        output = _run_main(["-f", "txt", "-q", "test"])
+        self.assertIn("[+] test (", output)
+        self.assertIn("CVE-", output)
+
+    def test_txt_to_file(self):
+        with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as f:
+            path = f.name
+        try:
+            _run_main(["-f", "txt", "-o", path, "-q", "test"])
+            with open(path) as f:
+                content = f.read()
+            self.assertIn("[+] test (", content)
+            self.assertIn("CVE-", content)
+        finally:
+            os.unlink(path)
+
+    def test_json_to_stdout(self):
+        output = _run_main(["-f", "json", "-q", "test"])
+        data = json.loads(output)
+        self.assertIn("test", data)
+        self.assertIn("vulns", data["test"])
+
+    def test_json_to_file(self):
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            path = f.name
+        try:
+            _run_main(["-f", "json", "-o", path, "-q", "test"])
+            with open(path) as f:
+                data = json.loads(f.read())
+            self.assertIn("test", data)
+        finally:
+            os.unlink(path)
+
+    def test_ansi_to_stdout_has_colors(self):
+        output = _run_main(["-f", "ansi", "-q", "test"])
+        self.assertIn("\033[", output)
+
+    def test_ansi_to_file_no_colors(self):
+        with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as f:
+            path = f.name
+        try:
+            _run_main(["-f", "ansi", "-o", path, "-q", "test"])
+            with open(path) as f:
+                content = f.read()
+            self.assertNotIn("\033[", content)
+            self.assertIn("CVE-", content)
+        finally:
+            os.unlink(path)
+
+    def test_md_to_stdout(self):
+        output = _run_main(["-f", "md", "-q", "test"])
+        self.assertTrue(output.strip().startswith("---"))
+        self.assertIn("|", output)
+
+    def test_md_to_file(self):
+        with tempfile.NamedTemporaryFile(suffix=".md", delete=False) as f:
+            path = f.name
+        try:
+            _run_main(["-f", "md", "-o", path, "-q", "test"])
+            with open(path) as f:
+                content = f.read()
+            self.assertIn("---", content)
+            self.assertIn("|", content)
+        finally:
+            os.unlink(path)
+
+    def test_md_multiple_queries(self):
+        output = _run_main(["-f", "md", "-q", "test1", "-q", "test2"])
+        self.assertEqual(output.count('cpe: "'), 2)
+
+
+# ------------------------------------------------ interactive mode
+class TestInteractiveMode(unittest.TestCase):
+    def test_interactive_dispatches(self):
+        with patch("sys.argv", ["search_vulns", "-i"]), \
+             patch("search_vulns.cli._load_config", return_value=_DUMMY_CONFIG), \
+             patch("search_vulns.cli.select_backend", return_value=_mock_backend()), \
+             patch("search_vulns.cli.run_interactive_loop") as mock_loop:
+            main()
+        mock_loop.assert_called_once()
+
+    def test_interactive_seed_queries(self):
+        with patch("sys.argv", ["search_vulns", "-i", "-q", "Apache"]), \
+             patch("search_vulns.cli._load_config", return_value=_DUMMY_CONFIG), \
+             patch("search_vulns.cli.select_backend", return_value=_mock_backend()), \
+             patch("search_vulns.cli.run_interactive_loop") as mock_loop:
+            main()
+        call_kwargs = mock_loop.call_args[1]
+        self.assertEqual(call_kwargs["seed_queries"], ["Apache"])
+
+    def test_interactive_default_format_ansi(self):
+        with patch("sys.argv", ["search_vulns", "-i"]), \
+             patch("search_vulns.cli._load_config", return_value=_DUMMY_CONFIG), \
+             patch("search_vulns.cli.select_backend", return_value=_mock_backend()), \
+             patch("search_vulns.cli.run_interactive_loop") as mock_loop:
+            main()
+
+        call_kwargs = mock_loop.call_args[1]
+        render_fn = call_kwargs["render_result"]
+
+        with patch("search_vulns.cli.format_ansi", return_value="ansi") as mock_ansi, \
+             patch("sys.stdout", StringIO()):
+            render_fn("test", _make_search_result())
+        mock_ansi.assert_called_once()
+
+    def test_interactive_explicit_format_md(self):
+        with patch("sys.argv", ["search_vulns", "-i", "-f", "md"]), \
+             patch("search_vulns.cli._load_config", return_value=_DUMMY_CONFIG), \
+             patch("search_vulns.cli.select_backend", return_value=_mock_backend()), \
+             patch("search_vulns.cli.run_interactive_loop") as mock_loop:
+            main()
+
+        call_kwargs = mock_loop.call_args[1]
+        render_fn = call_kwargs["render_result"]
+
+        with patch("search_vulns.cli.format_md", return_value="md") as mock_md, \
+             patch("sys.stdout", StringIO()):
+            render_fn("test", _make_search_result())
+        mock_md.assert_called_once()
+
+    def test_interactive_search_kwargs(self):
+        with patch("sys.argv", ["search_vulns", "-i", "--ignore-general-product-vulns"]), \
+             patch("search_vulns.cli._load_config", return_value=_DUMMY_CONFIG), \
+             patch("search_vulns.cli.select_backend", return_value=_mock_backend()), \
+             patch("search_vulns.cli.run_interactive_loop") as mock_loop:
+            main()
+        call_kwargs = mock_loop.call_args[1]
+        self.assertTrue(call_kwargs["search_kwargs"]["ignore_general_product_vulns"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cli_interactive.py
+++ b/tests/test_cli_interactive.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+
+import unittest
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+from search_vulns.cli_interactive import (
+    _gather_suggestions,
+    _pick_from_menu,
+    run_interactive_loop,
+)
+from search_vulns.models.SearchVulnsResult import (
+    PotProductIDsResult,
+    ProductIDsResult,
+    SearchVulnsResult,
+    VersionStatusResult,
+)
+from search_vulns.models.Severity import SeverityCVSS, SeverityType
+from search_vulns.models.Vulnerability import (
+    DataSource,
+    Match,
+    MatchReason,
+    Vulnerability,
+)
+
+
+# ------------------------------------------------ fixtures
+def _make_vuln(vid="CVE-FAKE"):
+    return Vulnerability(
+        id=vid,
+        match_reason=MatchReason.VERSION_IN_RANGE,
+        tracked_by={DataSource.NVD: f"https://nvd.nist.gov/vuln/detail/{vid}"},
+        matched_by={DataSource.NVD: Match(match_reason=MatchReason.VERSION_IN_RANGE, confidence=1.0)},
+        description="Test",
+        severity={SeverityType.CVSS: SeverityCVSS(score="7.5", version="3.1", vector="CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N")},
+        aliases={vid: f"https://nvd.nist.gov/vuln/detail/{vid}"},
+        published=datetime(2024, 1, 1),
+    )
+
+
+def _make_result(cpes=None, pot_cpes=None, purls=None, pot_purls=None):
+    return SearchVulnsResult(
+        product_ids=ProductIDsResult(cpe=cpes or [], purl=purls or []),
+        pot_product_ids=PotProductIDsResult(
+            cpe=pot_cpes or [], purl=pot_purls or [],
+        ),
+        vulns={},
+        version_status=VersionStatusResult(),
+    )
+
+
+def _make_search_result():
+    v = _make_vuln()
+    return SearchVulnsResult(
+        product_ids=ProductIDsResult(cpe=["cpe:2.3:a:v:p:1:*:*:*:*:*:*:*"]),
+        pot_product_ids=PotProductIDsResult(),
+        vulns={v.id: v},
+        version_status=VersionStatusResult(),
+    )
+
+
+def _mock_backend(suggest_result=None, search_result=None):
+    backend = MagicMock()
+    backend.suggest.return_value = suggest_result or _make_result(
+        pot_cpes=[("cpe:2.3:a:apache:tomcat:9.0.22:*:*:*:*:*:*:*", 0.95)]
+    )
+    backend.search.return_value = search_result or (True, _make_search_result())
+    return backend
+
+
+# ------------------------------------------------ _gather_suggestions
+class TestGatherSuggestions(unittest.TestCase):
+    def test_exact_cpes_first(self):
+        result = _make_result(
+            cpes=["cpe:exact"],
+            pot_cpes=[("cpe:fuzzy", 0.8)],
+        )
+        items = _gather_suggestions(result)
+        self.assertEqual(items[0][0], "cpe:exact")
+        self.assertEqual(items[0][1], 1.0)
+
+    def test_pot_sorted_by_score(self):
+        result = _make_result(
+            pot_cpes=[("cpe:low", 0.3), ("cpe:high", 0.9)],
+        )
+        items = _gather_suggestions(result)
+        self.assertEqual(items[0][0], "cpe:high")
+
+    def test_deduplicates(self):
+        result = _make_result(
+            cpes=["cpe:dup"],
+            pot_cpes=[("cpe:dup", 0.9)],
+        )
+        items = _gather_suggestions(result)
+        ids = [i[0] for i in items]
+        self.assertEqual(ids.count("cpe:dup"), 1)
+
+    def test_empty_result(self):
+        result = _make_result()
+        items = _gather_suggestions(result)
+        self.assertEqual(items, [])
+
+    def test_mixed_kinds(self):
+        result = _make_result(
+            cpes=["cpe:a"],
+            purls=["pkg:npm/foo"],
+            pot_cpes=[("cpe:b", 0.5)],
+        )
+        items = _gather_suggestions(result)
+        kinds = {i[2] for i in items}
+        self.assertIn("cpe", kinds)
+        self.assertIn("purl", kinds)
+
+
+# ------------------------------------------------ _pick_from_menu
+class TestPickFromMenu(unittest.TestCase):
+    def test_empty_items_returns_none(self):
+        self.assertIsNone(_pick_from_menu([]))
+
+    @patch("search_vulns.cli_interactive._prompt", return_value="1")
+    def test_valid_selection(self, _):
+        items = [("cpe:a", 0.9, "cpe"), ("cpe:b", 0.8, "cpe")]
+        result = _pick_from_menu(items)
+        self.assertEqual(result, "cpe:a")
+
+    @patch("search_vulns.cli_interactive._prompt", return_value="0")
+    def test_zero_skips(self, _):
+        items = [("cpe:a", 0.9, "cpe")]
+        result = _pick_from_menu(items)
+        self.assertIsNone(result)
+
+    @patch("search_vulns.cli_interactive._prompt", return_value="q")
+    def test_quit_returns_none(self, _):
+        items = [("cpe:a", 0.9, "cpe")]
+        result = _pick_from_menu(items)
+        self.assertIsNone(result)
+
+    @patch("search_vulns.cli_interactive._prompt", side_effect=["abc", "1"])
+    def test_invalid_then_valid(self, _):
+        items = [("cpe:a", 0.9, "cpe")]
+        result = _pick_from_menu(items)
+        self.assertEqual(result, "cpe:a")
+
+
+# ------------------------------------------------ run_interactive_loop
+class TestRunInteractiveLoop(unittest.TestCase):
+    @patch("search_vulns.cli_interactive._prompt", return_value="q")
+    def test_quit_on_q(self, _):
+        backend = _mock_backend()
+        render = MagicMock()
+        run_interactive_loop(backend, render_result=render, search_kwargs={})
+        backend.suggest.assert_not_called()
+        render.assert_not_called()
+
+    @patch("search_vulns.cli_interactive._prompt", return_value="exit")
+    def test_quit_on_exit(self, _):
+        backend = _mock_backend()
+        render = MagicMock()
+        run_interactive_loop(backend, render_result=render, search_kwargs={})
+        backend.suggest.assert_not_called()
+
+    @patch("builtins.input", side_effect=EOFError)
+    def test_quit_on_eof(self, _):
+        backend = _mock_backend()
+        render = MagicMock()
+        run_interactive_loop(backend, render_result=render, search_kwargs={})
+        backend.suggest.assert_not_called()
+
+    @patch("search_vulns.cli_interactive._pick_from_menu", return_value="cpe:2.3:a:apache:tomcat:9.0.22:*:*:*:*:*:*:*")
+    @patch("search_vulns.cli_interactive._prompt", side_effect=["q"])
+    def test_seed_queries_consumed_first(self, mock_prompt, mock_pick):
+        backend = _mock_backend()
+        render = MagicMock()
+        run_interactive_loop(
+            backend,
+            seed_queries=["Apache 2.4"],
+            render_result=render,
+            search_kwargs={},
+        )
+        backend.suggest.assert_called_once_with("Apache 2.4")
+        render.assert_called_once()
+
+    @patch("search_vulns.cli_interactive._pick_from_menu", return_value="cpe:2.3:a:apache:tomcat:9.0.22:*:*:*:*:*:*:*")
+    @patch("search_vulns.cli_interactive._prompt", side_effect=["q"])
+    def test_render_result_called(self, mock_prompt, mock_pick):
+        backend = _mock_backend()
+        render = MagicMock()
+        run_interactive_loop(
+            backend,
+            seed_queries=["test"],
+            render_result=render,
+            search_kwargs={},
+        )
+        render.assert_called_once()
+        args = render.call_args[0]
+        self.assertEqual(args[0], "test")
+
+    @patch("search_vulns.cli_interactive._pick_from_menu", return_value=None)
+    @patch("search_vulns.cli_interactive._prompt", side_effect=["q"])
+    def test_menu_skip_no_search(self, mock_prompt, mock_pick):
+        backend = _mock_backend()
+        render = MagicMock()
+        run_interactive_loop(
+            backend,
+            seed_queries=["test"],
+            render_result=render,
+            search_kwargs={},
+        )
+        backend.search.assert_not_called()
+        render.assert_not_called()
+
+    @patch("search_vulns.cli_interactive._prompt", side_effect=["Apache 2.4", "1", "q"])
+    def test_prompts_for_query(self, _):
+        backend = _mock_backend()
+        render = MagicMock()
+        run_interactive_loop(backend, render_result=render, search_kwargs={})
+        backend.suggest.assert_called_once_with("Apache 2.4")
+
+    @patch("search_vulns.cli_interactive._pick_from_menu", return_value="cpe:x")
+    @patch("search_vulns.cli_interactive._prompt", side_effect=["q"])
+    def test_search_kwargs_passed(self, mock_prompt, mock_pick):
+        backend = _mock_backend()
+        render = MagicMock()
+        run_interactive_loop(
+            backend,
+            seed_queries=["test"],
+            render_result=render,
+            search_kwargs={"ignore_general_product_vulns": True},
+        )
+        call_kwargs = backend.search.call_args
+        self.assertTrue(call_kwargs[1].get("ignore_general_product_vulns"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cve_completeness.py
+++ b/tests/test_cve_completeness.py
@@ -255,6 +255,7 @@ class TestSearches(unittest.TestCase):
             "CVE-2024-38819",
             "CVE-2025-22233",
             "CVE-2024-38808",
+            "CVE-2026-22735",
             "CVE-2026-22737",
         ]
         result_cves = [vuln_id for vuln_id in result.vulns.keys() if vuln_id.startswith("CVE-")]
@@ -275,6 +276,10 @@ class TestSearches(unittest.TestCase):
             "CVE-2021-3967",
             "CVE-2021-3866",
             "CVE-2022-31168",
+            "CVE-2026-25741",
+            "CVE-2025-25195",
+            "CVE-2026-25742",
+            "CVE-2026-26058",
         ]
         result_cves = [vuln_id for vuln_id in result.vulns.keys() if vuln_id.startswith("CVE-")]
         self.assertEqual(set(expected_cves), set(result_cves))
@@ -323,8 +328,6 @@ class TestSearches(unittest.TestCase):
             "CVE-2025-27149",
             "CVE-2025-52559",
             "CVE-2026-24050",
-            "CVE-2026-25741",
-            "CVE-2025-25195",
         ]
         result_cves = [vuln_id for vuln_id in result.vulns.keys() if vuln_id.startswith("CVE-")]
         self.assertEqual(set(expected_cves), set(result_cves))
@@ -344,6 +347,22 @@ class TestSearches(unittest.TestCase):
             "CVE-2023-44402",
             "CVE-2024-46993",
             "CVE-2025-55305",
+            "CVE-2026-34768",
+            "CVE-2026-34772",
+            "CVE-2026-34779",
+            "CVE-2026-34774",
+            "CVE-2026-34771",
+            "CVE-2026-34777",
+            "CVE-2026-34765",
+            "CVE-2026-34776",
+            "CVE-2026-34770",
+            "CVE-2026-34781",
+            "CVE-2026-34766",
+            "CVE-2026-34775",
+            "CVE-2026-34769",
+            "CVE-2026-34778",
+            "CVE-2026-34773",
+            "CVE-2026-34767",
         ]
         result_cves = [vuln_id for vuln_id in result.vulns.keys() if vuln_id.startswith("CVE-")]
         self.assertEqual(set(expected_cves), set(result_cves))

--- a/tests/test_eol_date.py
+++ b/tests/test_eol_date.py
@@ -80,7 +80,7 @@ class TestSearches(unittest.TestCase):
         result = search_vulns(query=query, is_product_id_query=True)
         expected_result = {
             "status": VersionStatus.OUTDATED,
-            "latest": "15.0.4460.4 CU32+GDR",
+            "latest": "15.0.4465.1 CU32+GDR",
             "reference": "https://endoflife.date/mssqlserver",
         }
         self.assertEqual(result.version_status.model_dump(), expected_result)

--- a/tests/test_exploit_completeness.py
+++ b/tests/test_exploit_completeness.py
@@ -43,6 +43,7 @@ class TestSearches(unittest.TestCase):
             "https://github.com/fofovicfof-ai/cve-2023-2745",
             "https://github.com/mufasa4o4/XML-RPC-Pingback-Vulnerability",
             "https://github.com/7rootsec/CVE-2022-21661-Technical-Analysis",
+            "https://github.com/TJouleL/WordPress-6.9.1-Blind-SSRF",
         ]
         result_exploits = []
         for vuln in result.vulns.values():
@@ -125,6 +126,8 @@ class TestSearches(unittest.TestCase):
             "https://github.com/dhmosfunk/CVE-2025-58098",
             "https://github.com/abanop22333/Apache-Authentication-Flaw-Research-CVE-2024-38476-",
             "https://github.com/yiliufeng168/CVE-2022-31813",
+            "https://github.com/MehranTurk/CVE-2023-45802",
+            "https://github.com/arnavps/CTF-Web-Exploitation",
         ]
         result_exploits = []
         for vuln in result.vulns.values():
@@ -160,7 +163,6 @@ class TestSearches(unittest.TestCase):
             "https://github.com/rapid7/metasploit-framework/tree/master/modules/exploits/unix/ftp/proftpd_133c_backdoor.rb",
             "https://www.exploit-db.com/exploits/16921",
             "https://github.com/lcartey/proftpd-cve-2019-12815",
-            "https://github.com/fumioryoto/Terrapin-attack",
         ]
         result_exploits = []
         for vuln in result.vulns.values():
@@ -197,6 +199,8 @@ class TestSearches(unittest.TestCase):
             "https://github.com/Cilectiy/CVE-2025-49844",
             "https://github.com/zbyszkok/CVE-2025-49844-RediShell-AI-made-Revshell",
             "https://github.com/0xBlackash/CVE-2025-49844",
+            "https://github.com/John-Popovici/CVE-2022-0543-redis-sandbox-escape",
+            "https://github.com/dajneem23/CVE-2025-49844",
         ]
         result_exploits = []
         for vuln in result.vulns.values():

--- a/tests/test_exploit_completeness.py
+++ b/tests/test_exploit_completeness.py
@@ -44,6 +44,7 @@ class TestSearches(unittest.TestCase):
             "https://github.com/mufasa4o4/XML-RPC-Pingback-Vulnerability",
             "https://github.com/7rootsec/CVE-2022-21661-Technical-Analysis",
             "https://github.com/TJouleL/WordPress-6.9.1-Blind-SSRF",
+            "https://github.com/TAPESH-TEAM/CVE-2022-21661-WordPress-Core-5.8.2-WP_Query-SQL-Injection",
         ]
         result_exploits = []
         for vuln in result.vulns.values():
@@ -128,6 +129,8 @@ class TestSearches(unittest.TestCase):
             "https://github.com/yiliufeng168/CVE-2022-31813",
             "https://github.com/MehranTurk/CVE-2023-45802",
             "https://github.com/arnavps/CTF-Web-Exploitation",
+            "https://gitee.com/Solitude-Echo/cve-2019-0211",
+            "https://github.com/Kashkovsky/CVE-2021-40438",
         ]
         result_exploits = []
         for vuln in result.vulns.values():
@@ -201,6 +204,11 @@ class TestSearches(unittest.TestCase):
             "https://github.com/0xBlackash/CVE-2025-49844",
             "https://github.com/John-Popovici/CVE-2022-0543-redis-sandbox-escape",
             "https://github.com/dajneem23/CVE-2025-49844",
+            "https://github.com/Mufti22/CVE-2025-49844-RediShell-Vulnerability-Scanner",
+            "https://github.com/JacobEbben/CVE-2022-0543",
+            "https://github.com/elyasbassir/CVE-2025-49844",
+            "https://github.com/raminfp/redis_exploit",
+            "https://github.com/vulhub/vulhub",
         ]
         result_exploits = []
         for vuln in result.vulns.values():

--- a/tests/test_redhat_backpatches.py
+++ b/tests/test_redhat_backpatches.py
@@ -15,7 +15,6 @@ class TestSearches(unittest.TestCase):
 
         expected_open = [
             "CVE-2025-53859",
-            "CVE-2026-1642",
             "CVE-2026-27651",
             "CVE-2026-27784",
             "CVE-2026-28753",
@@ -29,6 +28,7 @@ class TestSearches(unittest.TestCase):
             "CVE-2025-23419",
             "CVE-2021-3618",
             "CVE-2023-44487",
+            "CVE-2026-1642",
         ]
         result_open, result_backpatched = [], []
 
@@ -50,8 +50,6 @@ class TestSearches(unittest.TestCase):
             "CVE-2022-41317",
             "CVE-2025-59362",
             "CVE-2026-33515",
-            "CVE-2026-32748",
-            "CVE-2026-33526",
         ]
         expected_backpatched = [
             "CVE-2023-46728",
@@ -73,6 +71,8 @@ class TestSearches(unittest.TestCase):
             "CVE-2023-49286",
             "CVE-2024-37894",
             "CVE-2023-46724",
+            "CVE-2026-32748",
+            "CVE-2026-33526",
         ]
         result_open, result_backpatched = [], []
 

--- a/tests/test_ubuntu_backpatches.py
+++ b/tests/test_ubuntu_backpatches.py
@@ -13,7 +13,17 @@ class TestSearches(unittest.TestCase):
         query = "cpe:2.3:a:openssh:openssh:8.2:p1:*:*:*:*:*:ubuntu_focal_8.2p1-4ubuntu0.13"
         result = search_vulns(query=query, include_patched=True)
 
-        expected_open = ["CVE-2007-2768", "CVE-2008-3844", "CVE-2025-61984", "CVE-2025-61985"]
+        expected_open = [
+            "CVE-2007-2768",
+            "CVE-2008-3844",
+            "CVE-2025-61984",
+            "CVE-2025-61985",
+            "CVE-2026-35387",
+            "CVE-2026-35388",
+            "CVE-2026-35414",
+            "CVE-2026-35385",
+            "CVE-2026-35386",
+        ]
         expected_backpatched = [
             "CVE-2020-14145",
             "CVE-2020-15778",
@@ -98,6 +108,11 @@ class TestSearches(unittest.TestCase):
             "CVE-2016-5425",
             "CVE-2025-66614",
             "CVE-2026-24733",
+            "CVE-2026-34483",
+            "CVE-2026-25854",
+            "CVE-2026-24880",
+            "CVE-2026-34487",
+            "CVE-2026-29146",
         ]
         expected_backpatched = [
             "CVE-2025-55752",


### PR DESCRIPTION
This PR adds the following new parameters:
  - `--api-key`: for an API token against the web API
  - `--api-url`: default: <https://search-vulns.com/api/>
  - `--query-file`: batch processing of queries
  - `-i / --interactive`: interactive mode
  - `--vuln-count`: max no. of vulns 
  - `--md-cols`: which cols should be in the output (`id`, `cvss`, `description`, `epss`, `cwe`, `exploits`)

Additional output formats:
- ansi
- markdown