### PR TITLE
feat: integrate sv web api and batch processing

### DIFF
--- a/src/search_vulns/cli.py
+++ b/src/search_vulns/cli.py
@@ -3,109 +3,46 @@
 import argparse
 import json
 import os
-import re
 import sys
 
+from .cli_backend import DEFAULT_API_URL, select_backend
+from .cli_formatters import (
+    BRIGHT_BLUE,
+    RED,
+    YELLOW,
+    format_ansi,
+    format_json_batch,
+    format_md,
+    parse_md_cols,
+    print_vulns,
+    printit,
+    sort_and_cap_vulns,
+    strip_ansi,
+)
+from .cli_interactive import run_interactive_loop
 from .core import (
     DEFAULT_CONFIG_FILE,
     _load_config,
-    check_and_try_sv_rerun_with_created_cpes,
     get_modules,
     get_version,
     is_fully_installed,
-    search_vulns,
 )
 
-# define ANSI color escape sequences
-# Taken from: http://www.lihaoyi.com/post/BuildyourownCommandLinewithANSIescapecodes.html
-# and: http://www.topmudsites.com/forums/showthread.php?t=413
-SANE = "\u001b[0m"
-GREEN = "\u001b[32m"
-BRIGHT_GREEN = "\u001b[32;1m"
-RED = "\u001b[31m"
-YELLOW = "\u001b[33m"
-BRIGHT_BLUE = "\u001b[34;1m"
-MAGENTA = "\u001b[35m"
-BRIGHT_CYAN = "\u001b[36;1m"
 
-DEDUP_LINEBREAKS_RE_1 = re.compile(r"(\r\n)+")
-DEDUP_LINEBREAKS_RE_2 = re.compile(r"\n+")
+# ------------------------------------------------ helpers
+def _read_query_file(path: str) -> list:
+    try:
+        with open(path, encoding="utf-8") as fh:
+            return [
+                line.strip() for line in fh
+                if line.strip() and not line.strip().startswith("#")
+            ]
+    except OSError as exc:
+        print(f"Error: Cannot read query file '{path}': {exc}", file=sys.stderr)
+        sys.exit(1)
 
 
-def printit(text: str = "", end: str = "\n", color=SANE):
-    """A small print wrapper function"""
-
-    print(color, end="")
-    print(text, end=end)
-    if color != SANE:
-        print(SANE, end="")
-    sys.stdout.flush()
-
-
-def print_vulns(vulns, to_string=False):
-    """Print the supplied vulnerabilities"""
-
-    out_string = ""
-    vuln_ids_sorted = sorted(
-        list(vulns), key=lambda vuln_Id: vulns[vuln_Id].get_cvss_score(), reverse=True
-    )
-    for vuln_id in vuln_ids_sorted:
-        vuln_node = vulns[vuln_id]
-        description = DEDUP_LINEBREAKS_RE_2.sub(
-            "\n", DEDUP_LINEBREAKS_RE_1.sub("\r\n", vuln_node.description.strip())
-        )
-
-        if not to_string:
-            print_str = GREEN + vuln_node.id + SANE
-            print_str += (
-                " ("
-                + MAGENTA
-                + "CVSSv"
-                + str(vuln_node.get_cvss_version())
-                + "/"
-                + str(vuln_node.get_cvss_score())
-                + SANE
-                + ")"
-            )
-            if vuln_node.cisa_kev:
-                print_str += " (" + RED + "Actively exploited" + SANE + ")"
-        else:
-            print_str = vuln_node.id
-            print_str += (
-                " ("
-                "CVSSv"
-                + vuln_node.get_cvss_version()
-                + "/"
-                + str(vuln_node.get_cvss_score())
-                + ")"
-            )
-            if vuln_node.cisa_kev:
-                print_str += " (Actively exploited)"
-        print_str += ": " + description + "\n"
-
-        if vuln_node.exploits:
-            vuln_exploits = list(vuln_node.exploits)
-            if not to_string:
-                print_str += YELLOW + "Exploits:  " + SANE + vuln_exploits[0] + "\n"
-            else:
-                print_str += "Exploits:  " + vuln_exploits[0] + "\n"
-
-            if len(vuln_exploits) > 1:
-                for edb_link in vuln_exploits[1:]:
-                    print_str += len("Exploits:  ") * " " + edb_link + "\n"
-
-        print_str += "Reference: " + vuln_node.aliases[vuln_node.id]
-        if vuln_node.published:
-            print_str += ", " + vuln_node.published.strftime("%Y-%m-%d")
-        if not to_string:
-            printit(print_str)
-        else:
-            out_string += print_str + "\n"
-
-    if to_string:
-        return out_string
-
-
+# ------------------------------------------------ arg parsing
 def parse_args():
     """Parse command line arguments"""
 
@@ -146,8 +83,8 @@ def parse_args():
         "--format",
         type=str,
         default="txt",
-        choices={"txt", "json"},
-        help="Output format, either 'txt' or 'json' (default: 'txt')",
+        choices={"txt", "json", "ansi", "md"},
+        help="Output format: txt, json, ansi, or md (default: txt)",
     )
     parser.add_argument(
         "-o", "--output", type=str, help="File to write found vulnerabilities to"
@@ -199,6 +136,42 @@ def parse_args():
         action="store_true",
         help="Include vulnerabilities reported as (back)patched, e.g. by Debian Security Tracker, in results",
     )
+    parser.add_argument(
+        "--api-key",
+        type=str,
+        default=None,
+        help="API key for remote search (overrides SV_API_KEY env var)",
+    )
+    parser.add_argument(
+        "--api-url",
+        type=str,
+        default=None,
+        help=f"API base URL (default: {DEFAULT_API_URL})",
+    )
+    parser.add_argument(
+        "--query-file",
+        type=str,
+        default=None,
+        help="File with queries, one per line (# comments and blank lines skipped)",
+    )
+    parser.add_argument(
+        "-i",
+        "--interactive",
+        action="store_true",
+        help="Interactive mode: suggest product IDs, pick, then search",
+    )
+    parser.add_argument(
+        "--vuln-count",
+        type=int,
+        default=None,
+        help="Max number of vulnerabilities per query (sorted by criticality)",
+    )
+    parser.add_argument(
+        "--md-cols",
+        type=str,
+        default=None,
+        help="Columns for markdown format (default: id,cvss,description)",
+    )
 
     args = parser.parse_args()
     if (
@@ -209,11 +182,14 @@ def parse_args():
         and not args.version
         and not args.full_install
         and not args.list_modules
+        and not args.interactive
+        and not args.query_file
     ):
         parser.print_help()
     return args
 
 
+# ------------------------------------------------ main
 def main():
     # parse args and run update routine if requested
     args = parse_args()
@@ -283,107 +259,138 @@ def main():
         else:
             print("[+] Update successful")
 
-    if not args.queries:
+    # Collect queries
+    queries = list(args.queries or [])
+    if args.query_file:
+        queries.extend(_read_query_file(args.query_file))
+
+    if not queries and not args.interactive:
         return
 
-    # retrieve known vulnerabilities for every query and print them
+    # Select backend and build search kwargs
     config = _load_config(args.config)
+    backend = select_backend(args, config)
+
+    search_kwargs = {
+        "ignore_general_product_vulns": args.ignore_general_product_vulns,
+        "include_single_version_vulns": args.include_single_version_vulns,
+        "include_patched": args.include_patched,
+        "use_created_product_ids": args.use_created_product_ids,
+    }
+
+    fmt = args.format.lower()
+    if args.interactive and fmt == "txt":
+        fmt = "ansi"
+
+    md_cols = parse_md_cols(args.md_cols or "id,cvss,description")
+
+    # Interactive mode
+    if args.interactive:
+        def render_result(query, sv_result):
+            if args.vuln_count is not None:
+                sv_result.vulns = sort_and_cap_vulns(sv_result.vulns, args.vuln_count)
+            if fmt == "ansi":
+                print(format_ansi(query, sv_result))
+            elif fmt == "md":
+                print(format_md(sv_result, md_cols))
+            elif fmt == "txt":
+                all_product_ids = sv_result.product_ids.get_all()
+                printit("[+] %s (" % query, color=BRIGHT_BLUE, end="")
+                printit("/".join(all_product_ids) + ")", color=BRIGHT_BLUE)
+                print_vulns(sv_result.vulns)
+            elif fmt == "json":
+                print(json.dumps({query: sv_result.model_dump(exclude_none=True)}))
+
+        run_interactive_loop(
+            backend,
+            seed_queries=queries or None,
+            render_result=render_result,
+            search_kwargs=search_kwargs,
+        )
+        return
+
+    # Batch mode
     all_vulns = {}
     out_string = ""
-    for query in args.queries:
-        # Prepare arguments and search for vulnerabilities
+    md_blocks = []
+
+    for query in queries:
         query = query.strip()
 
-        if args.cpe_search_threshold:
-            config["MODULES"]["cpe_search.search_vulns_cpe_search"][
-                "CPE_SEARCH_THRESHOLD"
-            ] = args.cpe_search_threshold
-        config["MODULES"]["cpe_search.search_vulns_cpe_search"][
-            "CPE_SEARCH_COUNT"
-        ] = 1  # limit for CLI usage
-
-        if args.format.lower() == "txt":
+        if fmt == "txt":
             if not args.output:
                 printit("[+] %s (" % query, color=BRIGHT_BLUE, end="")
             else:
                 out_string += "[+] %s (" % query
 
-        sv_result = search_vulns(
-            query,
-            None,
-            None,
-            None,
-            False,
-            args.ignore_general_product_vulns,
-            args.include_single_version_vulns,
-            args.include_patched,
-            config,
-        )
-
-        # check if result is good, i.e. vulns or product IDs were found
-        is_good_result, sv_result = check_and_try_sv_rerun_with_created_cpes(
-            query,
-            sv_result,
-            args.ignore_general_product_vulns,
-            args.include_single_version_vulns,
-            args.include_patched,
-            args.use_created_product_ids,
-            config,
-        )
+        is_good_result, sv_result = backend.search(query, **search_kwargs)
         all_product_ids = sv_result.product_ids.get_all()
 
         if not is_good_result:
-            if args.format.lower() == "txt":
+            if fmt == "txt":
                 if not args.output:
                     printit(")", color=BRIGHT_BLUE)
                     printit("Warning: Could not find matching software for query", color=RED)
                     printit()
-                    continue
                 else:
                     out_string += ")\nWarning: Could not find matching software for query\n\n"
-            else:
+            elif fmt == "json":
                 all_vulns[query] = "Warning: Could not find matching software for query"
             continue
 
-        if args.format.lower() == "txt":
+        if fmt == "txt":
             if not args.output:
                 printit("/".join(all_product_ids) + ")", color=BRIGHT_BLUE)
             else:
                 out_string += "/".join(all_product_ids) + ")\n"
 
-        # "sort" vulnerabilities by CVSS score
-        if sv_result.vulns:
+        # Apply vuln-count capping
+        if args.vuln_count is not None:
+            sv_result.vulns = sort_and_cap_vulns(sv_result.vulns, args.vuln_count)
+
+        # Sort vulns by CVSS for txt/json (preserves original behavior)
+        if fmt in ("txt", "json") and sv_result.vulns:
             vuln_ids_sorted = sorted(
                 list(sv_result.vulns),
                 key=lambda vuln_id: sv_result.vulns[vuln_id].get_cvss_score(),
                 reverse=True,
             )
-            sorted_vulns = {}
-            for vuln_id in vuln_ids_sorted:
-                sorted_vulns[vuln_id] = sv_result.vulns[vuln_id]
-            sv_result.vulns = sorted_vulns
+            sv_result.vulns = {vid: sv_result.vulns[vid] for vid in vuln_ids_sorted}
 
-        # prepare output
-        if args.format.lower() == "txt":
-            # print found vulnerabilities
+        if fmt == "txt":
             if not args.output:
                 print_vulns(sv_result.vulns)
             else:
-                out_string += print_vulns(sv_result.vulns, to_string=True)
-        else:
-            sv_result = sv_result.model_dump(exclude_none=True)
+                out_string += print_vulns(sv_result.vulns, to_string=True) or ""
+        elif fmt == "ansi":
+            block = format_ansi(query, sv_result)
+            if not args.output:
+                print(block)
+            else:
+                out_string += strip_ansi(block) + "\n"
+        elif fmt == "md":
+            md_blocks.append(format_md(sv_result, md_cols))
 
         all_vulns[query] = sv_result
 
-    # provide final output
-    if args.output:
+    # Final output
+    if fmt == "json":
+        json_str = format_json_batch(all_vulns)
+        if args.output:
+            with open(args.output, "w") as f:
+                f.write(json_str)
+        else:
+            print(json_str)
+    elif fmt == "md":
+        md_output = "\n\n".join(md_blocks)
+        if args.output:
+            with open(args.output, "w") as f:
+                f.write(md_output)
+        else:
+            print(md_output)
+    elif args.output:
         with open(args.output, "w") as f:
-            if args.format.lower() == "json":
-                f.write(json.dumps(all_vulns))
-            else:
-                f.write(out_string)
-    elif args.format.lower() == "json":
-        print(json.dumps(all_vulns))
+            f.write(out_string)
 
 
 if __name__ == "__main__":

--- a/src/search_vulns/cli_backend.py
+++ b/src/search_vulns/cli_backend.py
@@ -1,0 +1,259 @@
+"""Backend abstraction for local DB and remote API searches"""
+
+import json
+import os
+import sys
+
+from typing import Protocol, Tuple
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote, urlencode
+from urllib.request import Request, urlopen
+
+from .models.SearchVulnsResult import (
+    PotProductIDsResult,
+    ProductIDsResult,
+    SearchVulnsResult,
+    VersionStatus,
+    VersionStatusResult,
+)
+from .models.Severity import SeverityCVSS, SeverityEPSS, SeverityType
+from .models.Vulnerability import DataSource, Match, MatchReason, Vulnerability
+
+from .core import search_vulns
+from .core import check_and_try_sv_rerun_with_created_cpes, search_vulns
+
+
+DEFAULT_API_URL = "https://search-vulns.com/api/"
+
+
+class ApiError(Exception):
+    pass
+
+
+class SearchBackend(Protocol):
+    def suggest(self, query: str) -> SearchVulnsResult: ...
+    def search(self, query: str, **kwargs) -> Tuple[bool, SearchVulnsResult]: ...
+
+
+# ------------------------------------------------ local backend
+class LocalBackend:
+    def __init__(self, config: dict, cli_overrides: dict | None = None):
+        self._config = config
+        self._overrides = cli_overrides or {}
+
+    def _apply_overrides(self, config: dict) -> dict:
+        import copy
+        cfg = copy.deepcopy(config)
+        if "cpe_search_threshold" in self._overrides and self._overrides["cpe_search_threshold"]:
+            cfg["MODULES"]["cpe_search.search_vulns_cpe_search"]["CPE_SEARCH_THRESHOLD"] = (
+                self._overrides["cpe_search_threshold"]
+            )
+        cfg["MODULES"]["cpe_search.search_vulns_cpe_search"]["CPE_SEARCH_COUNT"] = 1
+        return cfg
+
+    def suggest(self, query: str) -> SearchVulnsResult:
+        cfg = self._apply_overrides(self._config)
+        return search_vulns(query, config=cfg, skip_vuln_search=True)
+
+    def search(self, query: str, **kwargs) -> Tuple[bool, SearchVulnsResult]:
+        cfg = self._apply_overrides(self._config)
+        is_product_id = kwargs.get("is_good_product_id", False)
+
+        sv_result = search_vulns(
+            query,
+            None,
+            None,
+            None,
+            is_product_id,
+            kwargs.get("ignore_general_product_vulns", False),
+            kwargs.get("include_single_version_vulns", False),
+            kwargs.get("include_patched", False),
+            cfg,
+        )
+
+        is_good, sv_result = check_and_try_sv_rerun_with_created_cpes(
+            query,
+            sv_result,
+            kwargs.get("ignore_general_product_vulns", False),
+            kwargs.get("include_single_version_vulns", False),
+            kwargs.get("include_patched", False),
+            kwargs.get("use_created_product_ids", False),
+            cfg,
+        )
+        return is_good, sv_result
+
+
+# ------------------------------------------------ API backend
+class ApiBackend:
+    def __init__(self, api_key: str, api_url: str = DEFAULT_API_URL):
+        self._api_key = api_key
+        self._api_url = api_url.rstrip("/")
+
+    def _api_get(self, endpoint: str, params: dict, *, fatal: bool = True) -> dict:
+        qs = urlencode(params, quote_via=quote)
+        url = f"{self._api_url}{endpoint}?{qs}"
+        req = Request(url, headers={"API-Key": self._api_key})
+        errmsg = None
+
+        try:
+            with urlopen(req, timeout=30) as resp:
+                return json.loads(resp.read().decode())
+        except HTTPError as exc:
+            body = exc.read().decode()
+            try:
+                detail = json.loads(body)
+                msg = detail.get("message") or detail.get("detail") or body
+            except json.JSONDecodeError:
+                msg = body
+            errmsg = f"HTTP {exc.code}: {msg}"
+        except URLError as exc:
+            errmsg = f"Network error: {exc.reason}"
+
+        if fatal:
+            print(f"Error: {errmsg}", file=sys.stderr)
+            sys.exit(1)
+        raise ApiError(errmsg)
+
+    def suggest(self, query: str) -> SearchVulnsResult:
+        data = self._api_get("/product-id-suggestions", {"query": query})
+        return _parse_api_result(data)
+
+    def search(self, query: str, **kwargs) -> Tuple[bool, SearchVulnsResult]:
+        params: dict = {"query": query}
+
+        flag_map = {
+            "ignore_general_product_vulns": "ignore-general-product-vulns",
+            "include_single_version_vulns": "include-single-version-vulns",
+            "include_patched": "include-patched",
+            "use_created_product_ids": "use-created-product-ids",
+            "is_good_product_id": "is-good-product-id",
+        }
+        for attr, param in flag_map.items():
+            val = kwargs.get(attr)
+            if val is not None:
+                params[param] = str(val).lower()
+
+        data = self._api_get("/search-vulns", params)
+        result = _parse_api_result(data)
+        is_good = bool(result.product_ids.get_all()) or bool(result.vulns)
+        return is_good, result
+
+
+# ------------------------------------------------ API response parsing
+def _parse_severity(raw: dict) -> dict:
+    severity = {}
+    for _, entry in raw.items():
+        stype = entry.get("type", "")
+        if stype == "CVSS":
+            severity[SeverityType.CVSS] = SeverityCVSS(
+                score=str(entry.get("score", "0")),
+                version=str(entry.get("version", "0")),
+                vector=entry.get("vector", "n/a"),
+            )
+        elif stype == "EPSS":
+            severity[SeverityType.EPSS] = SeverityEPSS(
+                score=str(entry.get("score", "0")),
+            )
+    return severity
+
+
+def _parse_vuln(vid: str, raw: dict) -> Vulnerability:
+    tracked_by = {}
+    for src, ref in raw.get("tracked_by", {}).items():
+        try:
+            tracked_by[DataSource(src)] = ref
+        except ValueError:
+            tracked_by[src] = ref
+
+    matched_by = {}
+    for src, match_data in raw.get("matched_by", {}).items():
+        try:
+            ds = DataSource(src)
+        except ValueError:
+            ds = src
+        matched_by[ds] = Match(
+            match_reason=MatchReason(match_data.get("match_reason", "n_a")),
+            confidence=match_data.get("confidence", 1.0),
+        )
+
+    match_reason_str = raw.get("match_reason", "n_a")
+    try:
+        match_reason = MatchReason(match_reason_str)
+    except ValueError:
+        match_reason = MatchReason.N_A
+
+    kwargs = dict(
+        id=vid,
+        match_reason=match_reason,
+        tracked_by=tracked_by or {DataSource.OTHER: ""},
+        matched_by=matched_by or {DataSource.OTHER: Match(match_reason=match_reason, confidence=1.0)},
+        description=raw.get("description", ""),
+        severity=_parse_severity(raw.get("severity", {})),
+        cisa_kev=raw.get("cisa_kev", False),
+        exploits=set(raw.get("exploits", [])),
+        cwe_ids=set(raw.get("cwe_ids", [])),
+        aliases=raw.get("aliases", {vid: ""}),
+    )
+    if raw.get("published"):
+        kwargs["published"] = raw["published"]
+    if raw.get("modified"):
+        kwargs["modified"] = raw["modified"]
+
+    return Vulnerability(**kwargs)
+
+
+def _parse_api_result(data: dict) -> SearchVulnsResult:
+    pids = data.get("product_ids", {})
+    product_ids = ProductIDsResult(
+        cpe=pids.get("cpe", []),
+        purl=pids.get("purl", []),
+        raw=pids.get("raw", []),
+    )
+
+    pot = data.get("pot_product_ids", {})
+    pot_product_ids = PotProductIDsResult(
+        cpe=[(e[0], e[1]) for e in pot.get("cpe", [])],
+        purl=[(e[0], e[1]) for e in pot.get("purl", [])],
+        raw=[(e[0], e[1]) for e in pot.get("raw", [])],
+    )
+
+    vulns = {}
+    for vid, raw_vuln in data.get("vulns", {}).items():
+        vulns[vid] = _parse_vuln(vid, raw_vuln)
+
+    vs_data = data.get("version_status", {})
+    vs_status = None
+    if vs_data.get("status"):
+        try:
+            vs_status = VersionStatus(vs_data["status"])
+        except ValueError:
+            pass
+    version_status = VersionStatusResult(
+        status=vs_status,
+        latest=vs_data.get("latest"),
+        reference=vs_data.get("reference"),
+    )
+
+    return SearchVulnsResult(
+        product_ids=product_ids,
+        pot_product_ids=pot_product_ids,
+        vulns=vulns,
+        version_status=version_status,
+    )
+
+
+# ------------------------------------------------ backend selection
+def select_backend(args, config: dict) -> SearchBackend:
+    api_key = getattr(args, "api_key", None) or os.environ.get("SV_API_KEY")
+    api_url = getattr(args, "api_url", None)
+
+    if api_key or (api_url and api_url != DEFAULT_API_URL):
+        if not api_key:
+            print("Error: --api-url requires --api-key or SV_API_KEY env var.", file=sys.stderr)
+            sys.exit(1)
+        return ApiBackend(api_key, api_url or DEFAULT_API_URL)
+
+    overrides = {}
+    if hasattr(args, "cpe_search_threshold"):
+        overrides["cpe_search_threshold"] = args.cpe_search_threshold
+    return LocalBackend(config, overrides)

--- a/src/search_vulns/cli_formatters.py
+++ b/src/search_vulns/cli_formatters.py
@@ -1,0 +1,419 @@
+"""Provides txt, ansi, md, and json output formats"""
+
+import json
+import re
+from typing import Dict, Optional
+
+from .models.SearchVulnsResult import SearchVulnsResult
+from .models.Vulnerability import Vulnerability
+
+SANE = "\033[0m"
+GREEN = "\033[32m"
+BRIGHT_GREEN = "\033[32;1m"
+RED = "\033[31m"
+YELLOW = "\033[33m"
+BRIGHT_BLUE = "\033[34;1m"
+MAGENTA = "\033[35m"
+BRIGHT_CYAN = "\033[36;1m"
+BOLD = "\033[1m"
+DIM = "\033[2m"
+CYAN = "\033[36m"
+
+DEDUP_LINEBREAKS_RE_1 = re.compile(r"(\r\n)+")
+DEDUP_LINEBREAKS_RE_2 = re.compile(r"\n+")
+
+_ANSI_RE = re.compile(r"\033\[[0-9;]*m")
+
+ALLOWED_MD_COLS = ("id", "cvss", "description", "epss", "cwe", "exploits")
+DEFAULT_MD_COLS = ("id", "cvss", "description")
+
+_MD_COL_HEADERS = {
+    "id": "Vuln ID",
+    "cvss": "CVSS",
+    "description": "Description",
+    "epss": "EPSS",
+    "cwe": "CWE",
+    "exploits": "Exploits",
+}
+
+_MD_COL_ALIGN = {
+    "id": ":---:",
+    "cvss": ":---:",
+    "description": ":---",
+    "epss": ":---:",
+    "cwe": ":---:",
+    "exploits": ":---:",
+}
+
+_SEVERITY_ORDER = {"CRITICAL": 0, "HIGH": 1, "MEDIUM": 2, "LOW": 3, "UNKNOWN": 4}
+
+
+# ------------------------------------------------ helpers
+def printit(text: str = "", end: str = "\n", color=SANE):
+    """Small print wrapper with ANSI colour support."""
+    import sys
+
+    print(color, end="")
+    print(text, end=end)
+    if color != SANE:
+        print(SANE, end="")
+    sys.stdout.flush()
+
+
+def strip_ansi(text: str) -> str:
+    return _ANSI_RE.sub("", text)
+
+
+def _cvss_severity(score: float) -> str:
+    if score >= 9.0:
+        return "CRITICAL"
+    if score >= 7.0:
+        return "HIGH"
+    if score >= 4.0:
+        return "MEDIUM"
+    if score > 0.0:
+        return "LOW"
+    return "UNKNOWN"
+
+
+def _cvss_color(severity: str, color: bool = True) -> str:
+    if not color:
+        return ""
+    return {
+        "CRITICAL": RED,
+        "HIGH": RED,
+        "MEDIUM": YELLOW,
+        "LOW": GREEN,
+    }.get(severity, DIM)
+
+
+def _ansi(value: str, color: bool) -> str:
+    if color:
+        return value
+    return ""
+
+
+def _md_escape(text: str) -> str:
+    return text.replace("\\", "\\\\").replace("|", "\\|").replace("\r\n", " ").replace("\n", " ")
+
+
+def _parse_cpe(cpe: str) -> tuple:
+    parts = cpe.split(":")
+    vendor = parts[3] if len(parts) > 3 else ""
+    product = parts[4] if len(parts) > 4 else ""
+    version = parts[5] if len(parts) > 5 else ""
+    product = product.replace("_", " ").title()
+    vendor = vendor.replace("_", " ").title()
+    return vendor, product, version
+
+
+def parse_md_cols(raw: str) -> list:
+    cols = []
+    for col in raw.split(","):
+        col = col.strip().lower()
+        if not col:
+            continue
+        if col not in ALLOWED_MD_COLS:
+            raise ValueError(
+                f"Unknown markdown column '{col}'. Allowed: {', '.join(ALLOWED_MD_COLS)}"
+            )
+        if col not in cols:
+            cols.append(col)
+    if not cols:
+        return list(DEFAULT_MD_COLS)
+    return cols
+
+
+def sort_and_cap_vulns(
+    vulns: Dict[str, Vulnerability], max_count: Optional[int]
+) -> Dict[str, Vulnerability]:
+    if not vulns:
+        return {}
+
+    def sort_key(vuln_id):
+        v = vulns[vuln_id]
+        cvss = float(v.get_cvss_score())
+        epss_raw = v.get_epss_score()
+        epss = float(epss_raw) if epss_raw not in (None, "-1") else 0.0
+        return (-cvss, -epss, vuln_id)
+
+    sorted_ids = sorted(vulns.keys(), key=sort_key)
+
+    if max_count is not None:
+        sorted_ids = sorted_ids[:max_count]
+
+    return {vid: vulns[vid] for vid in sorted_ids}
+
+
+def score_bar(score: float, width: int = 12) -> str:
+    score = abs(score)
+    normalised = min(score, 1.0)
+    filled = round(normalised * width)
+    if score >= 0.6:
+        colour = GREEN
+    elif score >= 0.2:
+        colour = YELLOW
+    else:
+        colour = RED
+    bar = f"{colour}{'█' * filled}{DIM}{'░' * (width - filled)}{SANE}"
+    return f"{bar} {colour}{score:+.2f}{SANE}"
+
+
+# ------------------------------------------------ txt
+def print_vulns(vulns: Dict[str, Vulnerability], to_string: bool = False) -> Optional[str]:
+    out_string = ""
+    vuln_ids_sorted = sorted(
+        list(vulns), key=lambda vid: vulns[vid].get_cvss_score(), reverse=True
+    )
+    for vuln_id in vuln_ids_sorted:
+        vuln_node = vulns[vuln_id]
+        description = DEDUP_LINEBREAKS_RE_2.sub(
+            "\n", DEDUP_LINEBREAKS_RE_1.sub("\r\n", vuln_node.description.strip())
+        )
+
+        if not to_string:
+            print_str = GREEN + vuln_node.id + SANE
+            print_str += (
+                " ("
+                + MAGENTA
+                + "CVSSv"
+                + str(vuln_node.get_cvss_version())
+                + "/"
+                + str(vuln_node.get_cvss_score())
+                + SANE
+                + ")"
+            )
+            if vuln_node.cisa_kev:
+                print_str += " (" + RED + "Actively exploited" + SANE + ")"
+        else:
+            print_str = vuln_node.id
+            print_str += (
+                " ("
+                "CVSSv"
+                + vuln_node.get_cvss_version()
+                + "/"
+                + str(vuln_node.get_cvss_score())
+                + ")"
+            )
+            if vuln_node.cisa_kev:
+                print_str += " (Actively exploited)"
+        print_str += ": " + description + "\n"
+
+        if vuln_node.exploits:
+            vuln_exploits = list(vuln_node.exploits)
+            if not to_string:
+                print_str += YELLOW + "Exploits:  " + SANE + vuln_exploits[0] + "\n"
+            else:
+                print_str += "Exploits:  " + vuln_exploits[0] + "\n"
+
+            if len(vuln_exploits) > 1:
+                for edb_link in vuln_exploits[1:]:
+                    print_str += len("Exploits:  ") * " " + edb_link + "\n"
+
+        print_str += "Reference: " + vuln_node.aliases[vuln_node.id]
+        if vuln_node.published:
+            print_str += ", " + vuln_node.published.strftime("%Y-%m-%d")
+        if not to_string:
+            printit(print_str)
+        else:
+            out_string += print_str + "\n"
+
+    if to_string:
+        return out_string
+
+# ------------------------------------------------ ansi
+def _format_version_status(version_status, color: bool = True) -> str:
+    if not version_status or not version_status.status:
+        return ""
+
+    status = version_status.status.value if hasattr(version_status.status, "value") else str(version_status.status)
+    if status == "N/A":
+        return ""
+
+    status_color = {
+        "EOL": YELLOW,
+        "OUTDATED": YELLOW,
+        "CURRENT": GREEN,
+    }.get(status, DIM)
+
+    parts = [f"{_ansi(BOLD, color)}Status:{_ansi(SANE, color)} {_ansi(status_color, color)}{status}{_ansi(SANE, color)}"]
+    if version_status.latest:
+        parts.append(f"{_ansi(BOLD, color)}Latest:{_ansi(SANE, color)} {version_status.latest}")
+    if version_status.reference:
+        parts.append(f"{_ansi(DIM, color)}{version_status.reference}{_ansi(SANE, color)}")
+
+    return f"\n  {'  |  '.join(parts)}\n"
+
+
+def _format_vuln_table(vulns: Dict[str, Vulnerability], color: bool = True) -> str:
+    if not vulns:
+        return f"  {_ansi(GREEN, color)}No vulnerabilities found.{_ansi(SANE, color)}\n"
+
+    rows = []
+    for vid, vuln in vulns.items():
+        cvss = float(vuln.get_cvss_score())
+        epss_raw = vuln.get_epss_score()
+        epss = float(epss_raw) if epss_raw not in (None, "-1") else 0.0
+        severity = _cvss_severity(cvss)
+        sev_order = _SEVERITY_ORDER.get(severity, 99)
+
+        cvss_str = f"{cvss:.1f}"
+        cvss_ver = vuln.get_cvss_version()
+        if cvss_ver and str(cvss_ver) != "-1":
+            cvss_str += f"v{cvss_ver}"
+
+        epss_str = f"{epss:.2f}" if epss > 0 else "-"
+        published = vuln.published.strftime("%Y-%m-%d") if vuln.published else ""
+        desc = vuln.description or ""
+        if len(desc) > 60:
+            desc = desc[:57] + "..."
+
+        badges = ""
+        if vuln.cisa_kev:
+            badges += f" {_ansi(RED, color)}KEV{_ansi(SANE, color)}"
+        if vuln.exploits:
+            badges += f" {_ansi(MAGENTA, color)}EXP x{len(vuln.exploits)}{_ansi(SANE, color)}"
+
+        sev_color = _cvss_color(severity, color)
+        sane = _ansi(SANE, color)
+        line = (
+            f"  {sev_color}{vid:<20}{sane} "
+            f"{sev_color}{cvss_str:>7}{sane}  "
+            f"{epss_str:>5}  {published:<10}  {desc}{badges}"
+        )
+        rows.append((sev_order, -cvss, vid, line))
+
+    rows.sort(key=lambda r: (r[0], r[1], r[2]))
+
+    bold = _ansi(BOLD, color)
+    sane = _ansi(SANE, color)
+    lines = [
+        f"  {bold}{'ID':<20} {'CVSS':>7}  {'EPSS':>5}  {'Published':<10}  Description{sane}",
+        f"  {'─' * 78}",
+    ]
+
+    sev_names = {v: k for k, v in _SEVERITY_ORDER.items()}
+    current_sev = -1
+    for sev_order, _, _, line in rows:
+        if sev_order != current_sev:
+            current_sev = sev_order
+            label = sev_names.get(sev_order, "OTHER")
+            lines.append(f"\n  {bold}{_cvss_color(label, color)}── {label} ──{sane}")
+        lines.append(line)
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def format_ansi(query: str, sv_result: SearchVulnsResult, color: bool = True) -> str:
+    bold = _ansi(BOLD, color)
+    bright_blue = _ansi(BRIGHT_BLUE, color)
+    sane = _ansi(SANE, color)
+
+    parts = []
+
+    all_pids = sv_result.product_ids.get_all()
+    pid_str = "/".join(all_pids) if all_pids else "no product IDs"
+    parts.append(f"{bright_blue}[+] {query} ({pid_str}){sane}")
+
+    vs_str = _format_version_status(sv_result.version_status, color)
+    if vs_str:
+        parts.append(vs_str)
+
+    n = len(sv_result.vulns)
+    parts.append(
+        f"\n  {bold}{n} vulnerabilit{'y' if n == 1 else 'ies'} found{sane}\n"
+    )
+    parts.append(_format_vuln_table(sv_result.vulns, color))
+
+    return "\n".join(parts)
+
+
+# ------------------------------------------------ md
+def _md_frontmatter(sv_result: SearchVulnsResult) -> str:
+    cpes = sv_result.product_ids.cpe
+    if cpes:
+        cpe = cpes[0]
+        _, product, version = _parse_cpe(cpe)
+    else:
+        cpe = ""
+        product = ""
+        version = ""
+
+    lines = [
+        "---",
+        f'cpe: "{cpe}"',
+        f'product: "{product}"',
+        f'version: "{version}"',
+        "---",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def _md_cell(vuln: Vulnerability, col: str) -> str:
+    if col == "id":
+        ref = vuln.aliases.get(vuln.id, "")
+        if ref:
+            return f"[{_md_escape(vuln.id)}]({ref})"
+        return _md_escape(vuln.id)
+
+    if col == "cvss":
+        cvss = float(vuln.get_cvss_score())
+        if cvss < 0:
+            return "-"
+        ver = vuln.get_cvss_version()
+        if ver and str(ver) != "-1":
+            return f"{cvss} (v{ver})"
+        return str(cvss)
+
+    if col == "description":
+        return _md_escape(vuln.description or "")
+
+    if col == "epss":
+        epss_raw = vuln.get_epss_score()
+        epss = float(epss_raw) if epss_raw not in (None, "-1") else 0.0
+        if epss > 0:
+            return f"{epss:.2f}"
+        return "-"
+
+    if col == "cwe":
+        if vuln.cwe_ids:
+            return ", ".join(sorted(vuln.cwe_ids))
+        return "-"
+
+    if col == "exploits":
+        if vuln.exploits:
+            return str(len(vuln.exploits))
+        return "-"
+
+    return "-"
+
+
+def format_md(sv_result: SearchVulnsResult, cols: list) -> str:
+    parts = [_md_frontmatter(sv_result)]
+
+    headers = [_MD_COL_HEADERS.get(c, c) for c in cols]
+    aligns = [_MD_COL_ALIGN.get(c, ":---") for c in cols]
+
+    parts.append("| " + " | ".join(headers) + " |")
+    parts.append("| " + " | ".join(aligns) + " |")
+
+    sorted_vulns = sort_and_cap_vulns(sv_result.vulns, None)
+    for vid in sorted_vulns:
+        vuln = sorted_vulns[vid]
+        cells = [_md_cell(vuln, c) for c in cols]
+        parts.append("| " + " | ".join(cells) + " |")
+
+    return "\n".join(parts)
+
+
+# ------------------------------------------------ json
+def format_json_batch(all_results: dict) -> str:
+    serializable = {}
+    for query, result in all_results.items():
+        if isinstance(result, SearchVulnsResult):
+            serializable[query] = result.model_dump(exclude_none=True)
+        else:
+            serializable[query] = result
+    return json.dumps(serializable)

--- a/src/search_vulns/cli_interactive.py
+++ b/src/search_vulns/cli_interactive.py
@@ -1,0 +1,119 @@
+"""Interactive REPL: suggest -> pick -> search -> render loop"""
+
+import sys
+from typing import Callable
+
+from .cli_backend import SearchBackend
+from .cli_formatters import BOLD, CYAN, DIM, GREEN, RED, SANE, score_bar
+from .models.SearchVulnsResult import SearchVulnsResult
+
+_QUIT_WORDS = {"q", "quit", "exit"}
+
+
+# ------------------------------------------------ helpers
+def _prompt(text: str) -> str:
+    try:
+        return input(text).strip()
+    except (EOFError, KeyboardInterrupt):
+        print()
+        return "q"
+
+
+def _gather_suggestions(sv_result: SearchVulnsResult) -> list:
+    items = []
+    for cpe in sv_result.product_ids.cpe:
+        items.append((cpe, 1.0, "cpe"))
+    for purl in sv_result.product_ids.purl:
+        items.append((purl, 1.0, "purl"))
+    for raw in sv_result.product_ids.raw:
+        items.append((raw, 1.0, "raw"))
+
+    for cpe, score in sv_result.pot_product_ids.cpe:
+        if not any(i[0] == cpe for i in items):
+            items.append((cpe, abs(score), "cpe"))
+    for purl, score in sv_result.pot_product_ids.purl:
+        if not any(i[0] == purl for i in items):
+            items.append((purl, abs(score), "purl"))
+    for raw, score in sv_result.pot_product_ids.raw:
+        if not any(i[0] == raw for i in items):
+            items.append((raw, abs(score), "raw"))
+
+    items.sort(key=lambda x: -x[1])
+    return items
+
+
+def _pick_from_menu(items: list) -> str | None:
+    if not items:
+        return None
+
+    print(f"\n{BOLD}{CYAN}── Product IDs ──{SANE}\n")
+
+    for idx, (identifier, score, kind) in enumerate(items, 1):
+        print(f"  {BOLD}{idx:>3}{SANE})  {score_bar(score)}  [{kind}] {identifier}")
+
+    print(f"\n  {DIM}  0)  ← skip / new query{SANE}")
+    print()
+
+    while True:
+        raw = _prompt(f"{BOLD}Select [0–{len(items)}]:{SANE} ")
+        if raw.lower() in _QUIT_WORDS:
+            return None
+        if not raw:
+            continue
+        try:
+            choice = int(raw)
+        except ValueError:
+            print(f"  {RED}Please enter a number.{SANE}")
+            continue
+        if choice == 0:
+            return None
+        if 1 <= choice <= len(items):
+            selected = items[choice - 1][0]
+            print(f"\n{GREEN}Selected:{SANE} {BOLD}{selected}{SANE}\n")
+            return selected
+        print(f"  {RED}Out of range.{SANE}")
+
+
+# ------------------------------------------------ main loop
+def run_interactive_loop(
+    backend: SearchBackend,
+    *,
+    seed_queries: list | None = None,
+    render_result: Callable[[str, SearchVulnsResult], None],
+    search_kwargs: dict,
+):
+    pending = list(seed_queries or [])
+
+    while True:
+        if pending:
+            query = pending.pop(0)
+            print(f"\n{DIM}Query:{SANE} {BOLD}{query}{SANE}")
+        else:
+            query = _prompt(f"\n{BOLD}Enter query{SANE} ({DIM}q to quit{SANE}): ")
+            if query.lower() in _QUIT_WORDS:
+                break
+            if not query:
+                continue
+
+        print(f"{DIM}Searching suggestions...{SANE}", file=sys.stderr)
+        sv_suggest = backend.suggest(query)
+        items = _gather_suggestions(sv_suggest)
+
+        if not items:
+            print(f"{RED}No product IDs found for '{query}'.{SANE}")
+            continue
+
+        selected = _pick_from_menu(items)
+        if selected is None:
+            continue
+
+        print(f"{DIM}Searching vulnerabilities...{SANE}", file=sys.stderr)
+        is_good, sv_result = backend.search(
+            selected, is_good_product_id=True, **search_kwargs
+        )
+
+        if not is_good:
+            print(f"{RED}No results for '{selected}'.{SANE}")
+            continue
+
+        render_result(query, sv_result)

--- a/tests/run_all_tests.sh
+++ b/tests/run_all_tests.sh
@@ -61,5 +61,9 @@ echo '[+] Running test_redhat_backpatches.py'
 python3 "${SCRIPT_DIR}/test_redhat_backpatches.py"
 EXIT_12=$?
 
+echo '[+] Running test_cli_backend.py'
+python3 "${SCRIPT_DIR}/test_cli_backend.py"
+EXIT_13=$?
+
 # https://stackoverflow.com/a/16358989
-! (( $EXIT_1 || $EXIT_2 || $EXIT_3 || $EXIT_4 || $EXIT_7 || $EXIT_8 || $EXIT_9 || $EXIT_10 || $EXIT_11 || $EXIT_12 ))
+! (( $EXIT_1 || $EXIT_2 || $EXIT_3 || $EXIT_4 || $EXIT_7 || $EXIT_8 || $EXIT_9 || $EXIT_10 || $EXIT_11 || $EXIT_12  || $EXIT_13 ))

--- a/tests/run_all_tests.sh
+++ b/tests/run_all_tests.sh
@@ -65,5 +65,9 @@ echo '[+] Running test_cli_backend.py'
 python3 "${SCRIPT_DIR}/test_cli_backend.py"
 EXIT_13=$?
 
+echo '[+] Running test_cli_integration.py'
+python3 "${SCRIPT_DIR}/test_cli_integration.py"
+EXIT_14=$?
+
 # https://stackoverflow.com/a/16358989
-! (( $EXIT_1 || $EXIT_2 || $EXIT_3 || $EXIT_4 || $EXIT_7 || $EXIT_8 || $EXIT_9 || $EXIT_10 || $EXIT_11 || $EXIT_12  || $EXIT_13 ))
+! (( $EXIT_1 || $EXIT_2 || $EXIT_3 || $EXIT_4 || $EXIT_7 || $EXIT_8 || $EXIT_9 || $EXIT_10 || $EXIT_11 || $EXIT_12  || $EXIT_13 || $EXIT_14 ))

--- a/tests/test_cli_backend.py
+++ b/tests/test_cli_backend.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import os
+import unittest
+from io import BytesIO
+from unittest.mock import MagicMock, patch
+
+from search_vulns.cli_backend import (
+    DEFAULT_API_URL,
+    ApiBackend,
+    ApiError,
+    LocalBackend,
+    _parse_api_result,
+    select_backend,
+)
+from search_vulns.models.SearchVulnsResult import SearchVulnsResult
+
+
+# ------------------------------------------------ fixtures
+def _fake_api_json(
+    cpes=None, pot_cpes=None, vulns=None, version_status=None
+):
+    return json.dumps({
+        "product_ids": {"cpe": cpes or [], "purl": [], "raw": []},
+        "pot_product_ids": {"cpe": pot_cpes or [], "purl": [], "raw": []},
+        "vulns": vulns or {},
+        "version_status": version_status or {},
+    }).encode()
+
+
+def _mock_urlopen(response_bytes, status=200):
+    resp = MagicMock()
+    resp.read.return_value = response_bytes
+    resp.__enter__ = MagicMock(return_value=resp)
+    resp.__exit__ = MagicMock(return_value=False)
+    return resp
+
+
+# ------------------------------------------------ backend selection
+class TestBackendSelection(unittest.TestCase):
+    def _args(self, **kw):
+        defaults = {"api_key": None, "api_url": None, "cpe_search_threshold": None}
+        defaults.update(kw)
+        return argparse.Namespace(**defaults)
+
+    def test_no_api_flags_selects_local(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("SV_API_KEY", None)
+            backend = select_backend(self._args(), {})
+        self.assertIsInstance(backend, LocalBackend)
+
+    def test_api_key_flag_selects_api(self):
+        backend = select_backend(self._args(api_key="test-key"), {})
+        self.assertIsInstance(backend, ApiBackend)
+
+    def test_env_var_selects_api(self):
+        with patch.dict(os.environ, {"SV_API_KEY": "env-key"}):
+            backend = select_backend(self._args(), {})
+        self.assertIsInstance(backend, ApiBackend)
+
+    def test_custom_url_selects_api(self):
+        backend = select_backend(
+            self._args(api_key="k", api_url="https://custom.example.com/api/"), {}
+        )
+        self.assertIsInstance(backend, ApiBackend)
+
+    def test_api_key_precedence_over_env(self):
+        with patch.dict(os.environ, {"SV_API_KEY": "env-key"}):
+            backend = select_backend(self._args(api_key="flag-key"), {})
+        self.assertIsInstance(backend, ApiBackend)
+        self.assertEqual(backend._api_key, "flag-key")
+
+
+# ------------------------------------------------ API backend (mocked HTTP)
+class TestApiBackend(unittest.TestCase):
+    def _backend(self, api_url=None):
+        return ApiBackend("test-key", api_url or DEFAULT_API_URL)
+
+    @patch("search_vulns.cli_backend.urlopen")
+    def test_suggest_calls_correct_endpoint(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_urlopen(_fake_api_json())
+        self._backend().suggest("Apache 2.4")
+        call_args = mock_urlopen.call_args
+        req = call_args[0][0]
+        self.assertIn("/product-id-suggestions", req.full_url)
+        self.assertIn("query=Apache", req.full_url)
+
+    @patch("search_vulns.cli_backend.urlopen")
+    def test_suggest_sends_api_key_header(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_urlopen(_fake_api_json())
+        self._backend().suggest("test")
+        req = mock_urlopen.call_args[0][0]
+        self.assertEqual(req.get_header("Api-key"), "test-key")
+
+    @patch("search_vulns.cli_backend.urlopen")
+    def test_suggest_parses_response(self, mock_urlopen):
+        pot = [["cpe:2.3:a:apache:tomcat:9.0.22:*:*:*:*:*:*:*", 0.95]]
+        mock_urlopen.return_value = _mock_urlopen(_fake_api_json(pot_cpes=pot))
+        result = self._backend().suggest("Apache Tomcat 9")
+        self.assertIsInstance(result, SearchVulnsResult)
+        self.assertEqual(len(result.pot_product_ids.cpe), 1)
+
+    @patch("search_vulns.cli_backend.urlopen")
+    def test_search_calls_correct_endpoint(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_urlopen(_fake_api_json())
+        self._backend().search("cpe:2.3:a:apache:tomcat:9.0.22:*:*:*:*:*:*:*")
+        req = mock_urlopen.call_args[0][0]
+        self.assertIn("/search-vulns", req.full_url)
+
+    @patch("search_vulns.cli_backend.urlopen")
+    def test_search_passes_flags(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_urlopen(_fake_api_json())
+        self._backend().search("test", ignore_general_product_vulns=True)
+        req = mock_urlopen.call_args[0][0]
+        self.assertIn("ignore-general-product-vulns=true", req.full_url)
+
+    @patch("search_vulns.cli_backend.urlopen")
+    def test_http_error_non_fatal(self, mock_urlopen):
+        from urllib.error import HTTPError
+        mock_urlopen.side_effect = HTTPError(
+            "http://x", 500, "fail", {}, BytesIO(b'{"message":"err"}')
+        )
+        with self.assertRaises(ApiError):
+            self._backend()._api_get("/test", {}, fatal=False)
+
+    @patch("search_vulns.cli_backend.urlopen")
+    def test_http_error_fatal(self, mock_urlopen):
+        from urllib.error import HTTPError
+        mock_urlopen.side_effect = HTTPError(
+            "http://x", 500, "fail", {}, BytesIO(b'{"message":"err"}')
+        )
+        with self.assertRaises(SystemExit):
+            self._backend()._api_get("/test", {}, fatal=True)
+
+    @patch("search_vulns.cli_backend.urlopen")
+    def test_custom_api_url(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_urlopen(_fake_api_json())
+        self._backend(api_url="https://custom.example.com/api/").suggest("test")
+        req = mock_urlopen.call_args[0][0]
+        self.assertTrue(req.full_url.startswith("https://custom.example.com/api/"))
+
+
+# ------------------------------------------------ API response parsing
+class TestParseApiResult(unittest.TestCase):
+    def test_parses_product_ids(self):
+        data = json.loads(_fake_api_json(cpes=["cpe:2.3:a:v:p:1:*:*:*:*:*:*:*"]))
+        result = _parse_api_result(data)
+        self.assertEqual(result.product_ids.cpe, ["cpe:2.3:a:v:p:1:*:*:*:*:*:*:*"])
+
+    def test_parses_pot_product_ids(self):
+        pot = [["cpe:2.3:a:v:p:1:*:*:*:*:*:*:*", 0.85]]
+        data = json.loads(_fake_api_json(pot_cpes=pot))
+        result = _parse_api_result(data)
+        self.assertEqual(len(result.pot_product_ids.cpe), 1)
+        self.assertAlmostEqual(result.pot_product_ids.cpe[0][1], 0.85)
+
+    def test_parses_vulns(self):
+        vulns = {
+            "CVE-2024-0001": {
+                "match_reason": "version_in_range",
+                "tracked_by": {"nvd": "https://nvd.nist.gov/vuln/detail/CVE-2024-0001"},
+                "matched_by": {"nvd": {"match_reason": "version_in_range", "confidence": 1.0}},
+                "description": "Test vuln",
+                "severity": {
+                    "CVSS": {"type": "CVSS", "score": "7.5", "version": "3.1", "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"},
+                },
+                "cisa_kev": False,
+                "exploits": [],
+                "cwe_ids": ["CWE-79"],
+                "aliases": {"CVE-2024-0001": "https://nvd.nist.gov/vuln/detail/CVE-2024-0001"},
+            }
+        }
+        data = json.loads(_fake_api_json(vulns=vulns))
+        result = _parse_api_result(data)
+        self.assertIn("CVE-2024-0001", result.vulns)
+        v = result.vulns["CVE-2024-0001"]
+        self.assertEqual(float(v.get_cvss_score()), 7.5)
+        self.assertIn("CWE-79", v.cwe_ids)
+
+    def test_parses_version_status(self):
+        vs = {"status": "OUTDATED", "latest": "9.0.98", "reference": "https://example.com"}
+        data = json.loads(_fake_api_json(version_status=vs))
+        result = _parse_api_result(data)
+        self.assertEqual(result.version_status.status.value, "OUTDATED")
+        self.assertEqual(result.version_status.latest, "9.0.98")
+
+    def test_empty_response(self):
+        data = json.loads(_fake_api_json())
+        result = _parse_api_result(data)
+        self.assertIsInstance(result, SearchVulnsResult)
+        self.assertEqual(len(result.vulns), 0)
+        self.assertEqual(len(result.product_ids.cpe), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cli_formatters.py
+++ b/tests/test_cli_formatters.py
@@ -1,0 +1,383 @@
+#!/usr/bin/env python3
+
+import json
+import unittest
+from datetime import datetime
+
+from search_vulns.cli_formatters import (
+    ALLOWED_MD_COLS,
+    format_ansi,
+    format_json_batch,
+    format_md,
+    parse_md_cols,
+    print_vulns,
+    score_bar,
+    sort_and_cap_vulns,
+    strip_ansi,
+)
+from search_vulns.models.SearchVulnsResult import (
+    PotProductIDsResult,
+    ProductIDsResult,
+    SearchVulnsResult,
+    VersionStatus,
+    VersionStatusResult,
+)
+from search_vulns.models.Severity import SeverityCVSS, SeverityEPSS, SeverityType
+from search_vulns.models.Vulnerability import (
+    DataSource,
+    Match,
+    MatchReason,
+    Vulnerability,
+)
+
+
+# ------------------------------------------------ fixture helper
+def _make_vuln(
+    vid="CVE-2024-0001",
+    cvss=7.5,
+    cvss_ver="3.1",
+    epss=0.5,
+    desc="Test vulnerability",
+    cisa_kev=False,
+    exploits=None,
+    cwe_ids=None,
+    published=None,
+):
+    severity = {}
+    if cvss >= 0:
+        severity[SeverityType.CVSS] = SeverityCVSS(
+            score=str(cvss), version=str(cvss_ver), vector="CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
+        )
+    if epss > 0:
+        severity[SeverityType.EPSS] = SeverityEPSS(score=str(epss))
+
+    return Vulnerability(
+        id=vid,
+        match_reason=MatchReason.VERSION_IN_RANGE,
+        tracked_by={DataSource.NVD: f"https://nvd.nist.gov/vuln/detail/{vid}"},
+        matched_by={DataSource.NVD: Match(match_reason=MatchReason.VERSION_IN_RANGE, confidence=1.0)},
+        description=desc,
+        severity=severity,
+        cisa_kev=cisa_kev,
+        exploits=set(exploits or []),
+        cwe_ids=set(cwe_ids or []),
+        aliases={vid: f"https://nvd.nist.gov/vuln/detail/{vid}"},
+        published=published or datetime(2024, 1, 15, 0, 0, 0),
+    )
+
+
+def _make_result(vulns=None, cpes=None, version_status=None, pot_cpes=None):
+    return SearchVulnsResult(
+        product_ids=ProductIDsResult(cpe=cpes or []),
+        pot_product_ids=PotProductIDsResult(cpe=pot_cpes or []),
+        vulns={v.id: v for v in (vulns or [])},
+        version_status=version_status or VersionStatusResult(),
+    )
+
+
+# ------------------------------------------------ sort_and_cap_vulns
+class TestSortAndCap(unittest.TestCase):
+    def _vulns_dict(self, specs):
+        return {v.id: v for v in [_make_vuln(vid=s[0], cvss=s[1], epss=s[2]) for s in specs]}
+
+    def test_sort_by_cvss_desc(self):
+        vulns = self._vulns_dict([
+            ("CVE-A", 9.8, 0.1),
+            ("CVE-B", 4.0, 0.1),
+            ("CVE-C", 7.5, 0.1),
+            ("CVE-D", 0.0, 0.0),
+            ("CVE-E", 6.1, 0.1),
+        ])
+        result = sort_and_cap_vulns(vulns, None)
+        ids = list(result.keys())
+        self.assertEqual(ids, ["CVE-A", "CVE-C", "CVE-E", "CVE-B", "CVE-D"])
+
+    def test_sort_secondary_epss(self):
+        vulns = self._vulns_dict([("CVE-A", 7.5, 0.3), ("CVE-B", 7.5, 0.9)])
+        result = sort_and_cap_vulns(vulns, None)
+        ids = list(result.keys())
+        self.assertEqual(ids[0], "CVE-B")
+
+    def test_sort_tertiary_id(self):
+        vulns = self._vulns_dict([("CVE-B", 7.5, 0.5), ("CVE-A", 7.5, 0.5)])
+        result = sort_and_cap_vulns(vulns, None)
+        ids = list(result.keys())
+        self.assertEqual(ids, ["CVE-A", "CVE-B"])
+
+    def test_cap_truncates(self):
+        vulns = self._vulns_dict([(f"CVE-{i}", float(i), 0.1) for i in range(10)])
+        result = sort_and_cap_vulns(vulns, 3)
+        self.assertEqual(len(result), 3)
+
+    def test_cap_none_returns_all(self):
+        vulns = self._vulns_dict([(f"CVE-{i}", float(i), 0.1) for i in range(5)])
+        result = sort_and_cap_vulns(vulns, None)
+        self.assertEqual(len(result), 5)
+
+    def test_cap_zero_returns_empty(self):
+        vulns = self._vulns_dict([("CVE-A", 7.5, 0.5)])
+        result = sort_and_cap_vulns(vulns, 0)
+        self.assertEqual(len(result), 0)
+
+    def test_empty_vulns(self):
+        result = sort_and_cap_vulns({}, None)
+        self.assertEqual(result, {})
+
+
+# ------------------------------------------------ format_md
+class TestFormatMd(unittest.TestCase):
+    def test_default_cols(self):
+        result = _make_result([_make_vuln()])
+        out = format_md(result, list(ALLOWED_MD_COLS[:3]))
+        lines = out.strip().split("\n")
+        header_line = [l for l in lines if l.startswith("| Vuln")][0]
+        self.assertIn("Vuln ID", header_line)
+        self.assertIn("CVSS", header_line)
+        self.assertIn("Description", header_line)
+
+    def test_all_cols(self):
+        result = _make_result([_make_vuln(cwe_ids=["CWE-79"], exploits=["https://exploit.example"])])
+        out = format_md(result, list(ALLOWED_MD_COLS))
+        header_line = [l for l in out.split("\n") if l.startswith("| Vuln")][0]
+        for col_name in ("Vuln ID", "CVSS", "Description", "EPSS", "CWE", "Exploits"):
+            self.assertIn(col_name, header_line)
+
+    def test_frontmatter_from_cpe(self):
+        result = _make_result(
+            [_make_vuln()],
+            cpes=["cpe:2.3:a:apache:tomcat:9.0.22:*:*:*:*:*:*:*"],
+        )
+        out = format_md(result, ["id"])
+        self.assertIn('cpe: "cpe:2.3:a:apache:tomcat:9.0.22', out)
+        self.assertIn('product: "Tomcat"', out)
+        self.assertIn('version: "9.0.22"', out)
+
+    def test_frontmatter_no_cpe(self):
+        result = _make_result([_make_vuln()])
+        out = format_md(result, ["id"])
+        self.assertIn("---", out)
+        self.assertIn('cpe: ""', out)
+
+    def test_pipe_escaping(self):
+        result = _make_result([_make_vuln(desc="a | b")])
+        out = format_md(result, ["description"])
+        data_lines = [l for l in out.split("\n") if l.startswith("|") and "Description" not in l and ":---" not in l]
+        self.assertTrue(any("a \\| b" in l for l in data_lines))
+
+    def test_newline_escaping(self):
+        result = _make_result([_make_vuln(desc="line1\nline2")])
+        out = format_md(result, ["description"])
+        data_lines = [l for l in out.split("\n") if l.startswith("|") and "Description" not in l and ":---" not in l]
+        self.assertTrue(any("line1 line2" in l for l in data_lines))
+
+    def test_cvss_cell(self):
+        result = _make_result([_make_vuln(cvss=8.8, cvss_ver="3.1")])
+        out = format_md(result, ["cvss"])
+        self.assertIn("8.8 (v3.1)", out)
+
+    def test_cvss_cell_missing(self):
+        v = _make_vuln(cvss=-1)
+        v.severity = {}
+        result = _make_result([v])
+        out = format_md(result, ["cvss"])
+        data_lines = [l for l in out.split("\n") if l.startswith("|") and "CVSS" not in l and ":---" not in l]
+        self.assertTrue(any("| - |" in l for l in data_lines))
+
+    def test_epss_cell(self):
+        result = _make_result([_make_vuln(epss=0.84)])
+        out = format_md(result, ["epss"])
+        self.assertIn("0.84", out)
+
+    def test_epss_cell_zero(self):
+        result = _make_result([_make_vuln(epss=0)])
+        out = format_md(result, ["epss"])
+        data_lines = [l for l in out.split("\n") if l.startswith("|") and "EPSS" not in l and ":---" not in l]
+        self.assertTrue(any("| - |" in l for l in data_lines))
+
+    def test_cwe_cell(self):
+        result = _make_result([_make_vuln(cwe_ids=["CWE-89", "CWE-79"])])
+        out = format_md(result, ["cwe"])
+        self.assertIn("CWE-79, CWE-89", out)
+
+    def test_exploits_cell(self):
+        result = _make_result([_make_vuln(exploits=["http://a", "http://b", "http://c"])])
+        out = format_md(result, ["exploits"])
+        self.assertIn("3", out)
+
+    def test_id_cell_with_link(self):
+        result = _make_result([_make_vuln(vid="CVE-2024-1234")])
+        out = format_md(result, ["id"])
+        self.assertIn("[CVE-2024-1234](https://nvd.nist.gov/vuln/detail/CVE-2024-1234)", out)
+
+    def test_empty_vulns_produces_header_only(self):
+        result = _make_result([])
+        out = format_md(result, ["id", "cvss", "description"])
+        lines = [l for l in out.strip().split("\n") if l.startswith("|")]
+        self.assertEqual(len(lines), 2)  # header + alignment
+
+    def test_multiple_queries_separated(self):
+        r1 = _make_result([_make_vuln(vid="CVE-A")], cpes=["cpe:2.3:a:v:p:1:*:*:*:*:*:*:*"])
+        r2 = _make_result([_make_vuln(vid="CVE-B")], cpes=["cpe:2.3:a:v:q:2:*:*:*:*:*:*:*"])
+        out1 = format_md(r1, ["id"])
+        out2 = format_md(r2, ["id"])
+        combined = out1 + "\n\n" + out2
+        self.assertIn('cpe: "cpe:2.3:a:v:p:1', combined)
+        self.assertIn('cpe: "cpe:2.3:a:v:q:2', combined)
+        self.assertEqual(combined.count('cpe: "cpe:2.3:'), 2)
+
+
+# ------------------------------------------------ parse_md_cols
+class TestParseMdCols(unittest.TestCase):
+    def test_valid_subset(self):
+        self.assertEqual(parse_md_cols("id,epss"), ["id", "epss"])
+
+    def test_default_string(self):
+        self.assertEqual(parse_md_cols("id,cvss,description"), ["id", "cvss", "description"])
+
+    def test_invalid_col_rejected(self):
+        with self.assertRaises(ValueError):
+            parse_md_cols("id,foobar")
+
+    def test_whitespace_tolerant(self):
+        self.assertEqual(parse_md_cols(" id , cvss "), ["id", "cvss"])
+
+    def test_duplicate_deduped(self):
+        self.assertEqual(parse_md_cols("id,id,cvss"), ["id", "cvss"])
+
+
+# ------------------------------------------------ format_ansi
+class TestFormatAnsi(unittest.TestCase):
+    def test_severity_grouping(self):
+        vulns = [
+            _make_vuln(vid="CVE-CRIT", cvss=9.5),
+            _make_vuln(vid="CVE-MED", cvss=5.0),
+            _make_vuln(vid="CVE-LOW", cvss=2.0),
+        ]
+        out = format_ansi("test", _make_result(vulns))
+        plain = strip_ansi(out)
+        self.assertIn("CRITICAL", plain)
+        self.assertIn("MEDIUM", plain)
+        self.assertIn("LOW", plain)
+
+    def test_kev_badge(self):
+        out = format_ansi("test", _make_result([_make_vuln(cisa_kev=True)]))
+        plain = strip_ansi(out)
+        self.assertIn("KEV", plain)
+
+    def test_exploit_badge(self):
+        out = format_ansi("test", _make_result([_make_vuln(exploits=["http://a", "http://b"])]))
+        plain = strip_ansi(out)
+        self.assertIn("EXP x2", plain)
+
+    def test_version_status_banner(self):
+        vs = VersionStatusResult(status=VersionStatus.OUTDATED, latest="9.0.98")
+        out = format_ansi("test", _make_result([], version_status=vs))
+        plain = strip_ansi(out)
+        self.assertIn("OUTDATED", plain)
+        self.assertIn("9.0.98", plain)
+
+    def test_no_vulns_message(self):
+        out = format_ansi("test", _make_result([]))
+        plain = strip_ansi(out)
+        self.assertIn("No vulnerabilities found", plain)
+
+    def test_color_false_strips_ansi(self):
+        out = format_ansi("test", _make_result([_make_vuln()]), color=False)
+        self.assertNotIn("\033[", out)
+
+    def test_description_truncation(self):
+        long_desc = "A" * 200
+        out = format_ansi("test", _make_result([_make_vuln(desc=long_desc)]))
+        plain = strip_ansi(out)
+        self.assertIn("...", plain)
+        self.assertNotIn("A" * 200, plain)
+
+
+# ------------------------------------------------ format_json_batch
+class TestFormatJsonBatch(unittest.TestCase):
+    def test_valid_json(self):
+        results = {"q1": _make_result([_make_vuln()])}
+        out = format_json_batch(results)
+        parsed = json.loads(out)
+        self.assertIsInstance(parsed, dict)
+
+    def test_keys_are_queries(self):
+        results = {"query_a": _make_result(), "query_b": _make_result()}
+        out = format_json_batch(results)
+        parsed = json.loads(out)
+        self.assertIn("query_a", parsed)
+        self.assertIn("query_b", parsed)
+
+    def test_result_structure(self):
+        results = {"q": _make_result([_make_vuln()])}
+        out = format_json_batch(results)
+        parsed = json.loads(out)
+        self.assertIn("product_ids", parsed["q"])
+        self.assertIn("vulns", parsed["q"])
+
+    def test_warning_for_bad_result(self):
+        results = {"q": "Warning: Could not find matching software for query"}
+        out = format_json_batch(results)
+        parsed = json.loads(out)
+        self.assertIsInstance(parsed["q"], str)
+
+
+# ------------------------------------------------ print_vulns
+class TestPrintVulns(unittest.TestCase):
+    def test_to_string_returns_text(self):
+        vulns = {v.id: v for v in [_make_vuln(vid="CVE-2024-1111")]}
+        out = print_vulns(vulns, to_string=True)
+        self.assertIsNotNone(out)
+        self.assertIn("CVE-2024-1111", out)  # type: ignore[arg-type]
+
+    def test_to_string_no_ansi(self):
+        vulns = {v.id: v for v in [_make_vuln()]}
+        out = print_vulns(vulns, to_string=True)
+        self.assertIsNotNone(out)
+        self.assertNotIn("\033[", out)  # type: ignore[arg-type]
+
+    def test_exploit_display(self):
+        vulns = {v.id: v for v in [_make_vuln(exploits=["http://exploit1", "http://exploit2"])]}
+        out = print_vulns(vulns, to_string=True)
+        self.assertIsNotNone(out)
+        self.assertIn("http://exploit1", out)  # type: ignore[arg-type]
+        self.assertIn("http://exploit2", out)  # type: ignore[arg-type]
+
+    def test_published_date(self):
+        vulns = {v.id: v for v in [_make_vuln(published=datetime(2024, 3, 15))]}
+        out = print_vulns(vulns, to_string=True)
+        self.assertIsNotNone(out)
+        self.assertIn("2024-03-15", out)  # type: ignore[arg-type]
+
+    def test_kev_label(self):
+        vulns = {v.id: v for v in [_make_vuln(cisa_kev=True)]}
+        out = print_vulns(vulns, to_string=True)
+        self.assertIsNotNone(out)
+        self.assertIn("Actively exploited", out)  # type: ignore[arg-type]
+
+
+# ------------------------------------------------ score_bar
+class TestScoreBar(unittest.TestCase):
+    def test_full_score(self):
+        bar = strip_ansi(score_bar(1.0, width=12))
+        self.assertEqual(bar.count("█"), 12)
+        self.assertEqual(bar.count("░"), 0)
+
+    def test_zero_score(self):
+        bar = strip_ansi(score_bar(0.0, width=12))
+        self.assertEqual(bar.count("█"), 0)
+        self.assertEqual(bar.count("░"), 12)
+
+    def test_mid_score(self):
+        bar = strip_ansi(score_bar(0.5, width=12))
+        self.assertGreater(bar.count("█"), 0)
+        self.assertGreater(bar.count("░"), 0)
+
+    def test_negative_score_uses_abs(self):
+        bar_pos = strip_ansi(score_bar(0.8, width=12))
+        bar_neg = strip_ansi(score_bar(-0.8, width=12))
+        self.assertEqual(bar_pos.count("█"), bar_neg.count("█"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+
+import json
+import os
+import tempfile
+import unittest
+from datetime import datetime
+from io import StringIO
+from unittest.mock import MagicMock, patch
+
+from search_vulns.cli import _read_query_file, main, parse_args
+from search_vulns.models.SearchVulnsResult import (
+    PotProductIDsResult,
+    ProductIDsResult,
+    SearchVulnsResult,
+    VersionStatusResult,
+)
+from search_vulns.models.Severity import SeverityCVSS, SeverityType
+from search_vulns.models.Vulnerability import (
+    DataSource,
+    Match,
+    MatchReason,
+    Vulnerability,
+)
+
+
+# ------------------------------------------------ fixtures
+_DUMMY_CONFIG = {"DATABASE_CONNECTION": "none"}
+
+
+def _make_vuln(vid="CVE-FAKE", cvss_score="7.5"):
+    return Vulnerability(
+        id=vid,
+        match_reason=MatchReason.VERSION_IN_RANGE,
+        tracked_by={DataSource.NVD: f"https://nvd.nist.gov/vuln/detail/{vid}"},
+        matched_by={DataSource.NVD: Match(match_reason=MatchReason.VERSION_IN_RANGE, confidence=1.0)},
+        description="Test vulnerability",
+        severity={SeverityType.CVSS: SeverityCVSS(score=cvss_score, version="3.1", vector="CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N")},
+        aliases={vid: f"https://nvd.nist.gov/vuln/detail/{vid}"},
+        published=datetime(2024, 1, 1),
+    )
+
+
+def _make_search_result(n_vulns=3):
+    vulns = {}
+    for i in range(n_vulns):
+        vid = f"CVE-2024-{i:04d}"
+        score = str(round(max(0.1, 10.0 - i * 0.5), 1))
+        vulns[vid] = _make_vuln(vid, score)
+    return SearchVulnsResult(
+        product_ids=ProductIDsResult(cpe=["cpe:2.3:a:vendor:product:1.0:*:*:*:*:*:*:*"]),
+        pot_product_ids=PotProductIDsResult(),
+        vulns=vulns,
+        version_status=VersionStatusResult(),
+    )
+
+
+def _mock_backend(search_result=None, is_good=True):
+    backend = MagicMock()
+    if search_result is None:
+        search_result = _make_search_result()
+    backend.search.return_value = (is_good, search_result)
+    return backend
+
+
+def _run_main(argv, backend=None):
+    if backend is None:
+        backend = _mock_backend()
+    captured = StringIO()
+    with patch("sys.argv", ["search_vulns"] + argv), \
+         patch("search_vulns.cli._load_config", return_value=_DUMMY_CONFIG), \
+         patch("search_vulns.cli.select_backend", return_value=backend), \
+         patch("sys.stdout", captured):
+        main()
+    return captured.getvalue()
+
+
+# ------------------------------------------------ arg parsing
+class TestArgParsing(unittest.TestCase):
+    def _parse(self, argv):
+        with patch("sys.argv", ["search_vulns"] + argv):
+            return parse_args()
+
+    def test_api_key_parsed(self):
+        args = self._parse(["--api-key", "abc", "-q", "test"])
+        self.assertEqual(args.api_key, "abc")
+
+    def test_api_url_parsed(self):
+        args = self._parse(["--api-url", "https://x.com/api/", "--api-key", "k", "-q", "test"])
+        self.assertEqual(args.api_url, "https://x.com/api/")
+
+    def test_api_url_default_none(self):
+        args = self._parse(["-q", "test"])
+        self.assertIsNone(args.api_url)
+
+    def test_query_file_parsed(self):
+        args = self._parse(["--query-file", "f.txt"])
+        self.assertEqual(args.query_file, "f.txt")
+
+    def test_interactive_flag(self):
+        args = self._parse(["-i"])
+        self.assertTrue(args.interactive)
+
+    def test_vuln_count_parsed(self):
+        args = self._parse(["--vuln-count", "5", "-q", "test"])
+        self.assertEqual(args.vuln_count, 5)
+
+    def test_md_cols_parsed(self):
+        args = self._parse(["--md-cols", "id,epss,cwe", "-q", "test"])
+        self.assertEqual(args.md_cols, "id,epss,cwe")
+
+    def test_format_ansi(self):
+        args = self._parse(["-f", "ansi", "-q", "test"])
+        self.assertEqual(args.format, "ansi")
+
+    def test_format_md(self):
+        args = self._parse(["-f", "md", "-q", "test"])
+        self.assertEqual(args.format, "md")
+
+    def test_format_rejects_invalid(self):
+        with self.assertRaises(SystemExit):
+            self._parse(["-f", "invalid", "-q", "test"])
+
+    def test_existing_flags_unchanged(self):
+        self.assertTrue(self._parse(["-u"]).update)
+        self.assertTrue(self._parse(["--full-update"]).full_update)
+        self.assertTrue(self._parse(["-V"]).version)
+
+
+# ------------------------------------------------ query file reading
+class TestQueryFileReading(unittest.TestCase):
+    def _write_tmp(self, content):
+        f = tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False)
+        f.write(content)
+        f.close()
+        return f.name
+
+    def test_reads_lines(self):
+        path = self._write_tmp("query1\nquery2\nquery3\n")
+        try:
+            self.assertEqual(_read_query_file(path), ["query1", "query2", "query3"])
+        finally:
+            os.unlink(path)
+
+    def test_skips_blank_lines(self):
+        path = self._write_tmp("query1\n\nquery2\n\n\n")
+        try:
+            self.assertEqual(_read_query_file(path), ["query1", "query2"])
+        finally:
+            os.unlink(path)
+
+    def test_skips_comments(self):
+        path = self._write_tmp("# comment\nquery1\n# another\nquery2\n")
+        try:
+            self.assertEqual(_read_query_file(path), ["query1", "query2"])
+        finally:
+            os.unlink(path)
+
+    def test_strips_whitespace(self):
+        path = self._write_tmp("  query1  \n  query2\n")
+        try:
+            self.assertEqual(_read_query_file(path), ["query1", "query2"])
+        finally:
+            os.unlink(path)
+
+    def test_missing_file_exits(self):
+        with self.assertRaises(SystemExit):
+            _read_query_file("/nonexistent/path/file.txt")
+
+    def test_empty_file(self):
+        path = self._write_tmp("# only comments\n\n")
+        try:
+            self.assertEqual(_read_query_file(path), [])
+        finally:
+            os.unlink(path)
+
+    def test_combined_with_cli_queries(self):
+        path = self._write_tmp("C\nD\n")
+        try:
+            with patch("sys.argv", ["search_vulns", "-q", "A", "-q", "B", "--query-file", path]):
+                args = parse_args()
+            queries = list(args.queries or [])
+            queries.extend(_read_query_file(path))
+            self.assertEqual(queries, ["A", "B", "C", "D"])
+        finally:
+            os.unlink(path)
+
+
+# ------------------------------------------------ vuln count integration
+class TestVulnCountIntegration(unittest.TestCase):
+    def test_vuln_count_caps_output(self):
+        backend = _mock_backend(search_result=_make_search_result(20))
+        output = _run_main(["-f", "json", "--vuln-count", "5", "-q", "test"], backend)
+        data = json.loads(output)
+        self.assertEqual(len(data["test"]["vulns"]), 5)
+
+    def test_vuln_count_preserves_top(self):
+        backend = _mock_backend(search_result=_make_search_result(10))
+        output = _run_main(["-f", "json", "--vuln-count", "3", "-q", "test"], backend)
+        data = json.loads(output)
+        vuln_ids = list(data["test"]["vulns"].keys())
+        self.assertIn("CVE-2024-0000", vuln_ids)
+
+    def test_no_vuln_count_passes_all(self):
+        backend = _mock_backend(search_result=_make_search_result(10))
+        output = _run_main(["-f", "json", "-q", "test"], backend)
+        data = json.loads(output)
+        self.assertEqual(len(data["test"]["vulns"]), 10)
+
+
+# ------------------------------------------------ output routing
+class TestOutputRouting(unittest.TestCase):
+    def test_txt_to_stdout(self):
+        output = _run_main(["-f", "txt", "-q", "test"])
+        self.assertIn("[+] test (", output)
+        self.assertIn("CVE-", output)
+
+    def test_txt_to_file(self):
+        with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as f:
+            path = f.name
+        try:
+            _run_main(["-f", "txt", "-o", path, "-q", "test"])
+            with open(path) as f:
+                content = f.read()
+            self.assertIn("[+] test (", content)
+            self.assertIn("CVE-", content)
+        finally:
+            os.unlink(path)
+
+    def test_json_to_stdout(self):
+        output = _run_main(["-f", "json", "-q", "test"])
+        data = json.loads(output)
+        self.assertIn("test", data)
+        self.assertIn("vulns", data["test"])
+
+    def test_json_to_file(self):
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            path = f.name
+        try:
+            _run_main(["-f", "json", "-o", path, "-q", "test"])
+            with open(path) as f:
+                data = json.loads(f.read())
+            self.assertIn("test", data)
+        finally:
+            os.unlink(path)
+
+    def test_ansi_to_stdout_has_colors(self):
+        output = _run_main(["-f", "ansi", "-q", "test"])
+        self.assertIn("\033[", output)
+
+    def test_ansi_to_file_no_colors(self):
+        with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as f:
+            path = f.name
+        try:
+            _run_main(["-f", "ansi", "-o", path, "-q", "test"])
+            with open(path) as f:
+                content = f.read()
+            self.assertNotIn("\033[", content)
+            self.assertIn("CVE-", content)
+        finally:
+            os.unlink(path)
+
+    def test_md_to_stdout(self):
+        output = _run_main(["-f", "md", "-q", "test"])
+        self.assertTrue(output.strip().startswith("---"))
+        self.assertIn("|", output)
+
+    def test_md_to_file(self):
+        with tempfile.NamedTemporaryFile(suffix=".md", delete=False) as f:
+            path = f.name
+        try:
+            _run_main(["-f", "md", "-o", path, "-q", "test"])
+            with open(path) as f:
+                content = f.read()
+            self.assertIn("---", content)
+            self.assertIn("|", content)
+        finally:
+            os.unlink(path)
+
+    def test_md_multiple_queries(self):
+        output = _run_main(["-f", "md", "-q", "test1", "-q", "test2"])
+        self.assertEqual(output.count('cpe: "'), 2)
+
+
+# ------------------------------------------------ interactive mode
+class TestInteractiveMode(unittest.TestCase):
+    def test_interactive_dispatches(self):
+        with patch("sys.argv", ["search_vulns", "-i"]), \
+             patch("search_vulns.cli._load_config", return_value=_DUMMY_CONFIG), \
+             patch("search_vulns.cli.select_backend", return_value=_mock_backend()), \
+             patch("search_vulns.cli.run_interactive_loop") as mock_loop:
+            main()
+        mock_loop.assert_called_once()
+
+    def test_interactive_seed_queries(self):
+        with patch("sys.argv", ["search_vulns", "-i", "-q", "Apache"]), \
+             patch("search_vulns.cli._load_config", return_value=_DUMMY_CONFIG), \
+             patch("search_vulns.cli.select_backend", return_value=_mock_backend()), \
+             patch("search_vulns.cli.run_interactive_loop") as mock_loop:
+            main()
+        call_kwargs = mock_loop.call_args[1]
+        self.assertEqual(call_kwargs["seed_queries"], ["Apache"])
+
+    def test_interactive_default_format_ansi(self):
+        with patch("sys.argv", ["search_vulns", "-i"]), \
+             patch("search_vulns.cli._load_config", return_value=_DUMMY_CONFIG), \
+             patch("search_vulns.cli.select_backend", return_value=_mock_backend()), \
+             patch("search_vulns.cli.run_interactive_loop") as mock_loop:
+            main()
+
+        call_kwargs = mock_loop.call_args[1]
+        render_fn = call_kwargs["render_result"]
+
+        with patch("search_vulns.cli.format_ansi", return_value="ansi") as mock_ansi, \
+             patch("sys.stdout", StringIO()):
+            render_fn("test", _make_search_result())
+        mock_ansi.assert_called_once()
+
+    def test_interactive_explicit_format_md(self):
+        with patch("sys.argv", ["search_vulns", "-i", "-f", "md"]), \
+             patch("search_vulns.cli._load_config", return_value=_DUMMY_CONFIG), \
+             patch("search_vulns.cli.select_backend", return_value=_mock_backend()), \
+             patch("search_vulns.cli.run_interactive_loop") as mock_loop:
+            main()
+
+        call_kwargs = mock_loop.call_args[1]
+        render_fn = call_kwargs["render_result"]
+
+        with patch("search_vulns.cli.format_md", return_value="md") as mock_md, \
+             patch("sys.stdout", StringIO()):
+            render_fn("test", _make_search_result())
+        mock_md.assert_called_once()
+
+    def test_interactive_search_kwargs(self):
+        with patch("sys.argv", ["search_vulns", "-i", "--ignore-general-product-vulns"]), \
+             patch("search_vulns.cli._load_config", return_value=_DUMMY_CONFIG), \
+             patch("search_vulns.cli.select_backend", return_value=_mock_backend()), \
+             patch("search_vulns.cli.run_interactive_loop") as mock_loop:
+            main()
+        call_kwargs = mock_loop.call_args[1]
+        self.assertTrue(call_kwargs["search_kwargs"]["ignore_general_product_vulns"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cli_interactive.py
+++ b/tests/test_cli_interactive.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+
+import unittest
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+from search_vulns.cli_interactive import (
+    _gather_suggestions,
+    _pick_from_menu,
+    run_interactive_loop,
+)
+from search_vulns.models.SearchVulnsResult import (
+    PotProductIDsResult,
+    ProductIDsResult,
+    SearchVulnsResult,
+    VersionStatusResult,
+)
+from search_vulns.models.Severity import SeverityCVSS, SeverityType
+from search_vulns.models.Vulnerability import (
+    DataSource,
+    Match,
+    MatchReason,
+    Vulnerability,
+)
+
+
+# ------------------------------------------------ fixtures
+def _make_vuln(vid="CVE-FAKE"):
+    return Vulnerability(
+        id=vid,
+        match_reason=MatchReason.VERSION_IN_RANGE,
+        tracked_by={DataSource.NVD: f"https://nvd.nist.gov/vuln/detail/{vid}"},
+        matched_by={DataSource.NVD: Match(match_reason=MatchReason.VERSION_IN_RANGE, confidence=1.0)},
+        description="Test",
+        severity={SeverityType.CVSS: SeverityCVSS(score="7.5", version="3.1", vector="CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N")},
+        aliases={vid: f"https://nvd.nist.gov/vuln/detail/{vid}"},
+        published=datetime(2024, 1, 1),
+    )
+
+
+def _make_result(cpes=None, pot_cpes=None, purls=None, pot_purls=None):
+    return SearchVulnsResult(
+        product_ids=ProductIDsResult(cpe=cpes or [], purl=purls or []),
+        pot_product_ids=PotProductIDsResult(
+            cpe=pot_cpes or [], purl=pot_purls or [],
+        ),
+        vulns={},
+        version_status=VersionStatusResult(),
+    )
+
+
+def _make_search_result():
+    v = _make_vuln()
+    return SearchVulnsResult(
+        product_ids=ProductIDsResult(cpe=["cpe:2.3:a:v:p:1:*:*:*:*:*:*:*"]),
+        pot_product_ids=PotProductIDsResult(),
+        vulns={v.id: v},
+        version_status=VersionStatusResult(),
+    )
+
+
+def _mock_backend(suggest_result=None, search_result=None):
+    backend = MagicMock()
+    backend.suggest.return_value = suggest_result or _make_result(
+        pot_cpes=[("cpe:2.3:a:apache:tomcat:9.0.22:*:*:*:*:*:*:*", 0.95)]
+    )
+    backend.search.return_value = search_result or (True, _make_search_result())
+    return backend
+
+
+# ------------------------------------------------ _gather_suggestions
+class TestGatherSuggestions(unittest.TestCase):
+    def test_exact_cpes_first(self):
+        result = _make_result(
+            cpes=["cpe:exact"],
+            pot_cpes=[("cpe:fuzzy", 0.8)],
+        )
+        items = _gather_suggestions(result)
+        self.assertEqual(items[0][0], "cpe:exact")
+        self.assertEqual(items[0][1], 1.0)
+
+    def test_pot_sorted_by_score(self):
+        result = _make_result(
+            pot_cpes=[("cpe:low", 0.3), ("cpe:high", 0.9)],
+        )
+        items = _gather_suggestions(result)
+        self.assertEqual(items[0][0], "cpe:high")
+
+    def test_deduplicates(self):
+        result = _make_result(
+            cpes=["cpe:dup"],
+            pot_cpes=[("cpe:dup", 0.9)],
+        )
+        items = _gather_suggestions(result)
+        ids = [i[0] for i in items]
+        self.assertEqual(ids.count("cpe:dup"), 1)
+
+    def test_empty_result(self):
+        result = _make_result()
+        items = _gather_suggestions(result)
+        self.assertEqual(items, [])
+
+    def test_mixed_kinds(self):
+        result = _make_result(
+            cpes=["cpe:a"],
+            purls=["pkg:npm/foo"],
+            pot_cpes=[("cpe:b", 0.5)],
+        )
+        items = _gather_suggestions(result)
+        kinds = {i[2] for i in items}
+        self.assertIn("cpe", kinds)
+        self.assertIn("purl", kinds)
+
+
+# ------------------------------------------------ _pick_from_menu
+class TestPickFromMenu(unittest.TestCase):
+    def test_empty_items_returns_none(self):
+        self.assertIsNone(_pick_from_menu([]))
+
+    @patch("search_vulns.cli_interactive._prompt", return_value="1")
+    def test_valid_selection(self, _):
+        items = [("cpe:a", 0.9, "cpe"), ("cpe:b", 0.8, "cpe")]
+        result = _pick_from_menu(items)
+        self.assertEqual(result, "cpe:a")
+
+    @patch("search_vulns.cli_interactive._prompt", return_value="0")
+    def test_zero_skips(self, _):
+        items = [("cpe:a", 0.9, "cpe")]
+        result = _pick_from_menu(items)
+        self.assertIsNone(result)
+
+    @patch("search_vulns.cli_interactive._prompt", return_value="q")
+    def test_quit_returns_none(self, _):
+        items = [("cpe:a", 0.9, "cpe")]
+        result = _pick_from_menu(items)
+        self.assertIsNone(result)
+
+    @patch("search_vulns.cli_interactive._prompt", side_effect=["abc", "1"])
+    def test_invalid_then_valid(self, _):
+        items = [("cpe:a", 0.9, "cpe")]
+        result = _pick_from_menu(items)
+        self.assertEqual(result, "cpe:a")
+
+
+# ------------------------------------------------ run_interactive_loop
+class TestRunInteractiveLoop(unittest.TestCase):
+    @patch("search_vulns.cli_interactive._prompt", return_value="q")
+    def test_quit_on_q(self, _):
+        backend = _mock_backend()
+        render = MagicMock()
+        run_interactive_loop(backend, render_result=render, search_kwargs={})
+        backend.suggest.assert_not_called()
+        render.assert_not_called()
+
+    @patch("search_vulns.cli_interactive._prompt", return_value="exit")
+    def test_quit_on_exit(self, _):
+        backend = _mock_backend()
+        render = MagicMock()
+        run_interactive_loop(backend, render_result=render, search_kwargs={})
+        backend.suggest.assert_not_called()
+
+    @patch("builtins.input", side_effect=EOFError)
+    def test_quit_on_eof(self, _):
+        backend = _mock_backend()
+        render = MagicMock()
+        run_interactive_loop(backend, render_result=render, search_kwargs={})
+        backend.suggest.assert_not_called()
+
+    @patch("search_vulns.cli_interactive._pick_from_menu", return_value="cpe:2.3:a:apache:tomcat:9.0.22:*:*:*:*:*:*:*")
+    @patch("search_vulns.cli_interactive._prompt", side_effect=["q"])
+    def test_seed_queries_consumed_first(self, mock_prompt, mock_pick):
+        backend = _mock_backend()
+        render = MagicMock()
+        run_interactive_loop(
+            backend,
+            seed_queries=["Apache 2.4"],
+            render_result=render,
+            search_kwargs={},
+        )
+        backend.suggest.assert_called_once_with("Apache 2.4")
+        render.assert_called_once()
+
+    @patch("search_vulns.cli_interactive._pick_from_menu", return_value="cpe:2.3:a:apache:tomcat:9.0.22:*:*:*:*:*:*:*")
+    @patch("search_vulns.cli_interactive._prompt", side_effect=["q"])
+    def test_render_result_called(self, mock_prompt, mock_pick):
+        backend = _mock_backend()
+        render = MagicMock()
+        run_interactive_loop(
+            backend,
+            seed_queries=["test"],
+            render_result=render,
+            search_kwargs={},
+        )
+        render.assert_called_once()
+        args = render.call_args[0]
+        self.assertEqual(args[0], "test")
+
+    @patch("search_vulns.cli_interactive._pick_from_menu", return_value=None)
+    @patch("search_vulns.cli_interactive._prompt", side_effect=["q"])
+    def test_menu_skip_no_search(self, mock_prompt, mock_pick):
+        backend = _mock_backend()
+        render = MagicMock()
+        run_interactive_loop(
+            backend,
+            seed_queries=["test"],
+            render_result=render,
+            search_kwargs={},
+        )
+        backend.search.assert_not_called()
+        render.assert_not_called()
+
+    @patch("search_vulns.cli_interactive._prompt", side_effect=["Apache 2.4", "1", "q"])
+    def test_prompts_for_query(self, _):
+        backend = _mock_backend()
+        render = MagicMock()
+        run_interactive_loop(backend, render_result=render, search_kwargs={})
+        backend.suggest.assert_called_once_with("Apache 2.4")
+
+    @patch("search_vulns.cli_interactive._pick_from_menu", return_value="cpe:x")
+    @patch("search_vulns.cli_interactive._prompt", side_effect=["q"])
+    def test_search_kwargs_passed(self, mock_prompt, mock_pick):
+        backend = _mock_backend()
+        render = MagicMock()
+        run_interactive_loop(
+            backend,
+            seed_queries=["test"],
+            render_result=render,
+            search_kwargs={"ignore_general_product_vulns": True},
+        )
+        call_kwargs = backend.search.call_args
+        self.assertTrue(call_kwargs[1].get("ignore_general_product_vulns"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds the following new parameters:
  - `--api-key`: for an API token against the web API
  - `--api-url`: default: <https://search-vulns.com/api/>
  - `--query-file`: batch processing of queries
  - `-i / --interactive`: interactive mode
  - `--vuln-count`: max no. of vulns 
  - `--md-cols`: which cols should be in the output (`id`, `cvss`, `description`, `epss`, `cwe`, `exploits`)

Additional output formats:
- ansi
- markdown

Closes #34 as well.